### PR TITLE
feat: switch to async/await

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "standard-version": "^4.2.0"
   },
   "scripts": {
-    "lint": "standard",
+    "lint": "standard --fix",
     "pretest": "standard",
     "test": "node_modules/mocha/bin/mocha spec/**/*.spec.js",
     "coverage": "nyc npm test",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "dependencies": {
     "@npm-wharf/mcgonagall": "1.9.x",
+    "async-retry": "^1.2.1",
     "auto-kubernetes-client": "^0.5.1",
     "bluebird": "^3.5.1",
     "bole": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -45,9 +45,9 @@
   "scripts": {
     "lint": "standard --fix",
     "pretest": "standard",
-    "test": "node_modules/mocha/bin/mocha spec/**/*.spec.js",
+    "test": "mocha spec/**/*.spec.js",
     "coverage": "nyc npm test",
-    "continuous": "./node_modules/mocha/bin/mocha spec/*.spec.js -w",
+    "continuous": "mocha spec/*.spec.js -w",
     "release": "standard-version",
     "standard": "standard --fix"
   },

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "standard-version": "^4.2.0"
   },
   "scripts": {
+    "lint": "standard",
     "pretest": "standard",
     "test": "node_modules/mocha/bin/mocha spec/**/*.spec.js",
     "coverage": "nyc npm test",

--- a/spec/integration/index.spec.js
+++ b/spec/integration/index.spec.js
@@ -1,0 +1,11 @@
+const hikaru = require('../../src/')
+const {expect} = require('chai')
+
+const thrown = Symbol('thrown')
+
+describe('hikaru API', () => {
+  it('should make coverage cry', async () => {
+    const itThrew = await hikaru.runJob().catch(() => thrown)
+    expect(itThrew).to.equal(thrown)
+  })
+})

--- a/src/cluster.js
+++ b/src/cluster.js
@@ -1,6 +1,5 @@
 const Promise = require('bluebird')
 const _ = require('lodash')
-const join = Promise.join
 const log = require('bole')('cluster')
 const parse = require('./imageParser').parse
 const compare = require('./imageComparer').compare
@@ -23,249 +22,196 @@ const MANIFEST_KIND_FILTER = [
   'StatefulSet'
 ]
 
-function createAccount (k8s, resources) {
-  let accountPromise
+async function createAccount (k8s, resources) {
   if (resources.account) {
     log.info(`    creating account '${resources.account.metadata.name}'`)
-    accountPromise = k8s.createAccount(resources.account)
+    await k8s.createAccount(resources.account)
       .then(
         onAccountCreated.bind(null, k8s, resources),
         onAccountCreationFailed.bind(null, resources.account)
       )
-  } else {
-    accountPromise = Promise.resolve()
   }
-  return accountPromise
 }
 
-function createConfiguration (k8s, cluster) {
+async function createConfiguration (k8s, cluster) {
   const promises = cluster.configuration.map(configuration => {
     log.info(`creating configuration map: '${configuration.metadata.namespace}.${configuration.metadata.name}'`)
     return k8s.createConfiguration(configuration)
   })
-  return Promise.all(promises)
+  await Promise.all(promises)
 }
 
-function createContainer (k8s, resources) {
+async function createContainer (k8s, resources) {
   const spec = getContainerSpec(resources)
-  const create = () => {
-    return getContainer(k8s, resources)
-      .then(
-        null,
-        onContainerCreationFailed.bind(null, spec)
-      )
-  }
   if (resources.job || resources.cronjob) {
-    return createContainerServices(k8s, resources)
-      .then(create)
-  } else {
-    return create()
+    await createContainerServices(k8s, resources)
   }
+  await getContainer(k8s, resources)
+    .catch(
+      onContainerCreationFailed.bind(null, spec)
+    )
 }
 
-function createContainerServices (k8s, resources) {
+async function createContainerServices (k8s, resources) {
   const services = resources.services || []
-  return Promise.all(services.map(service => {
+  await Promise.all(services.map(service => {
     log.info(`    creating service '${service.metadata.name}'`)
     return k8s.createService(service)
-      .then(
-        null,
+      .catch(
         onServiceCreationFailed.bind(null, service)
       )
   }))
 }
 
-function createLevels (k8s, cluster) {
-  return Promise.each(cluster.levels, (level) => {
+async function createLevels (k8s, cluster) {
+  await Promise.each(cluster.levels, (level) => {
     log.info(`creating level: ${level}`)
     return createServicesInLevel(k8s, level, cluster)
   })
 }
 
-function createNamespaces (k8s, cluster) {
+async function createNamespaces (k8s, cluster) {
   const promises = cluster.namespaces.map(namespace => {
     log.info(`creating namespace: '${namespace}'`)
     return k8s.createNamespace(namespace)
   })
-  promises.push(k8s.fixNamespaceLabels())
-  return Promise.all(promises)
+  await Promise.all(promises)
+  await k8s.fixNamespaceLabels()
 }
 
-function createNetworkPolicy (k8s, resources) {
-  let policyPromise
+async function createNetworkPolicy (k8s, resources) {
   if (resources.networkPolicy) {
     log.info(`  creating network policy '${resources.networkPolicy.metadata.namespace}.${resources.networkPolicy.metadata.name}'`)
-    policyPromise = k8s.createNetworkPolicy(resources.networkPolicy)
-      .then(
-        null,
+    await k8s.createNetworkPolicy(resources.networkPolicy)
+      .catch(
         onNetworkPolicyCreationFailed.bind(null, resources.networkPolicy)
       )
-  } else {
-    policyPromise = Promise.resolve()
   }
-  return policyPromise
 }
 
-function createRole (k8s, resources) {
-  let bindingPromise
+async function createRole (k8s, resources) {
   if (resources.role) {
     log.info(`    creating role '${resources.roleBinding.metadata.namespace || 'Cluster'}.${resources.roleBinding.metadata.name}'`)
-    bindingPromise = k8s.createRole(resources.role)
-      .then(
-        null,
+    await k8s.createRole(resources.role)
+      .catch(
         onRoleCreationFailed.bind(null, resources.role)
       )
-  } else {
-    bindingPromise = Promise.resolve()
   }
-  return bindingPromise
 }
 
-function createRoleBinding (k8s, resources) {
-  let bindingPromise
+async function createRoleBinding (k8s, resources) {
   if (resources.roleBinding) {
     log.info(`    creating role binding '${resources.roleBinding.metadata.namespace || 'Cluster'}.${resources.roleBinding.metadata.name}'`)
-    bindingPromise = k8s.createRoleBinding(resources.roleBinding)
-      .then(
-        null,
+    await k8s.createRoleBinding(resources.roleBinding)
+      .catch(
         onRoleBindingCreationFailed.bind(null, resources.roleBinding)
       )
-  } else {
-    bindingPromise = Promise.resolve()
   }
-  return bindingPromise
 }
 
-function createServicesInLevel (k8s, level, cluster) {
+async function createServicesInLevel (k8s, level, cluster) {
   const promises = cluster.order[level].reduce((acc, serviceName) => {
     log.info(`  creating resources for '${serviceName}'`)
     return acc.concat(createServiceResources(k8s, cluster.services[serviceName]))
   }, [])
-  return Promise.all(promises)
+  await Promise.all(promises)
 }
 
-function createServiceResources (k8s, resources) {
-  return createAccount(k8s, resources)
+async function createServiceResources (k8s, resources) {
+  await createAccount(k8s, resources)
+  await createContainer(k8s, resources)
     .then(
-      () => {
-        return createContainer(k8s, resources)
-          .then(
-            onContainerCreated.bind(null, k8s, resources)
-          )
-      }
+      onContainerCreated.bind(null, k8s, resources)
     )
 }
 
-function deleteAccount (k8s, resources) {
-  let accountPromise
+async function deleteAccount (k8s, resources) {
   if (resources.account) {
     log.info(`    deleting account '${resources.account.metadata.name}'`)
-    accountPromise = k8s.deleteAccount(resources.account)
-      .then(
-        null,
+    await k8s.deleteAccount(resources.account)
+      .catch(
         onAccountDeletionFailed.bind(null, resources.account)
       )
-  } else {
-    accountPromise = Promise.resolve()
   }
-  return accountPromise
 }
 
-function deleteConfiguration (k8s, cluster) {
-  const promises = cluster.configuration.map(configuration => {
+async function deleteConfiguration (k8s, cluster) {
+  const promises = cluster.configuration.map(async configuration => {
     log.info(`deleting configuration map: '${configuration.metadata.namespace}.${configuration.metadata.name}'`)
     if (_.includes(RESERVED_NAMESPACES, configuration.metadata.namespace)) {
-      return k8s.deleteConfiguration(configuration)
+      await k8s.deleteConfiguration(configuration)
     }
-    return Promise.resolve()
   })
-  return Promise.all(promises)
+  await Promise.all(promises)
 }
 
-function deleteContainer (k8s, resources) {
+async function deleteContainer (k8s, resources) {
   const spec = getContainerSpec(resources)
-  return removeContainer(k8s, resources)
-    .then(
-      null,
+  await removeContainer(k8s, resources)
+    .catch(
       onContainerDeletionFailed.bind(null, spec)
     )
 }
 
-function deleteContainerServices (k8s, resources) {
+async function deleteContainerServices (k8s, resources) {
   const services = resources.services || []
-  return Promise.all(services.map(service => {
+  await Promise.all(services.map(async service => {
     log.info(`    deleting service '${service.metadata.name}'`)
-    return k8s.deleteService(service)
-      .then(
-        null,
+    await k8s.deleteService(service)
+      .catch(
         onServiceDeletionFailed.bind(null, service)
       )
   }))
 }
 
-function deleteLevels (k8s, cluster) {
+async function deleteLevels (k8s, cluster) {
   cluster.levels.reverse()
-  return Promise.each(cluster.levels, (level) => {
+  await Promise.each(cluster.levels, (level) => {
     log.info(`deleting level: ${level}`)
     return deleteServicesInLevel(k8s, level, cluster)
   })
 }
 
-function deleteNamespaces (k8s, cluster) {
+async function deleteNamespaces (k8s, cluster) {
   const namespaces = _.difference(cluster.namespaces, RESERVED_NAMESPACES)
   const promises = namespaces.map(namespace => {
     log.info(`deleting namespace: '${namespace}'`)
     return k8s.deleteNamespace(namespace)
   })
-  return Promise.all(promises)
+  await Promise.all(promises)
 }
 
-function deleteNetworkPolicy (k8s, resources) {
-  let policyPromise
+async function deleteNetworkPolicy (k8s, resources) {
   if (resources.networkPolicy) {
     log.info(`  deleting network policy '${resources.networkPolicy.metadata.namespace}.${resources.networkPolicy.metadata.name}'`)
-    policyPromise = k8s.deleteNetworkPolicy(resources.networkPolicy)
-      .then(
-        null,
+    await k8s.deleteNetworkPolicy(resources.networkPolicy)
+      .catch(
         onNetworkPolicyDeletionFailed.bind(null, resources.networkPolicy)
       )
-  } else {
-    policyPromise = Promise.resolve()
   }
-  return policyPromise
 }
 
-function deleteRole (k8s, resources) {
-  let bindingPromise
+async function deleteRole (k8s, resources) {
   if (resources.role) {
     log.info(`    deleting role '${resources.roleBinding.metadata.namespace}'.${resources.roleBinding.metadata.name}'`)
-    bindingPromise = k8s.deleteRole(resources.roleBinding)
-      .then(
-        null,
+    await k8s.deleteRole(resources.roleBinding)
+      .catch(
         onRoleDeletionFailed.bind(null, resources.roleBinding)
       )
-  } else {
-    bindingPromise = Promise.resolve()
   }
-  return bindingPromise
 }
 
-function deleteRoleBinding (k8s, resources) {
-  let bindingPromise
+async function deleteRoleBinding (k8s, resources) {
   if (resources.roleBinding) {
     log.info(`    deleting role binding '${resources.roleBinding.metadata.name}'`)
-    bindingPromise = k8s.deleteRoleBinding(resources.roleBinding)
-      .then(
-        null,
+    await k8s.deleteRoleBinding(resources.roleBinding)
+      .catch(
         onRoleBindingDeletionFailed.bind(null, resources.roleBinding)
       )
-  } else {
-    bindingPromise = Promise.resolve()
   }
-  return bindingPromise
 }
 
-function deleteServicesInLevel (k8s, level, cluster) {
+async function deleteServicesInLevel (k8s, level, cluster) {
   const promises = cluster.order[level].reduce((acc, serviceName) => {
     const reserved = _.includes(RESERVED_NAMESPACES, cluster.services[serviceName].namespace)
     if (reserved) {
@@ -275,22 +221,20 @@ function deleteServicesInLevel (k8s, level, cluster) {
       return acc
     }
   }, [])
-  return Promise.all(promises)
+  await Promise.all(promises)
 }
 
-function deleteServiceResources (k8s, resources) {
-  return deleteAccount(k8s, resources)
-    .then(
-      onAccountDeleted.bind(null, k8s, resources)
-    )
+async function deleteServiceResources (k8s, resources) {
+  await deleteAccount(k8s, resources)
+  await onAccountDeleted(k8s, resources)
 }
 
-function deployCluster (k8s, cluster) {
-  return createNamespaces(k8s, cluster)
-    .then(
-      onNamespacesCreated.bind(null, k8s, cluster),
+async function deployCluster (k8s, cluster) {
+  await createNamespaces(k8s, cluster)
+    .catch(
       onNamespaceCreationFailed.bind(null, cluster)
     )
+  await onNamespacesCreated(k8s, cluster)
 }
 
 function exitOnError () {
@@ -302,66 +246,58 @@ function filterContainerManifests (manifest) {
     MANIFEST_KIND_FILTER.indexOf(manifest.kind) < 0
 }
 
-function findResourcesByImage (k8s, image) {
-  let testResource = (list, resource) => {
+async function findResourcesByImage (k8s, image) {
+  let testResource = list => resource => {
     if (resource.image.indexOf(image) >= 0) {
       list.push(resource)
     }
   }
 
-  return getImageMetadata(k8s, {baseImage: image})
-    .then(
-      images => {
-        const namespaces = Object.keys(images)
-        return namespaces.reduce((acc, namespace) => {
-          const resources = images[namespace]
-          resources.daemonSets.forEach(testResource.bind(null, acc))
-          resources.deployments.forEach(testResource.bind(null, acc))
-          resources.statefulSets.forEach(testResource.bind(null, acc))
-          return acc
-        }, [])
-      }
-    )
+  const images = await getImageMetadata(k8s, {baseImage: image})
+  const namespaces = Object.keys(images)
+  return namespaces.reduce((acc, namespace) => {
+    const resources = images[namespace]
+    resources.daemonSets.forEach(testResource(acc))
+    resources.deployments.forEach(testResource(acc))
+    resources.statefulSets.forEach(testResource(acc))
+    return acc
+  }, [])
 }
 
-function findResourcesByMetadata (k8s, metadata) {
-  let testResource = (list, resource) => {
+async function findResourcesByMetadata (k8s, metadata) {
+  let testResource = list => resource => {
     if (match(resource.metadata, metadata, resource.labels)) {
       list.push(resource)
     }
   }
 
-  return getImageMetadata(k8s)
-    .then(
-      images => {
-        const namespaces = Object.keys(images)
-        return namespaces.reduce((acc, namespace) => {
-          const resources = images[namespace]
-          resources.daemonSets.forEach(testResource.bind(null, acc))
-          resources.deployments.forEach(testResource.bind(null, acc))
-          resources.statefulSets.forEach(testResource.bind(null, acc))
-          return acc
-        }, [])
-      }
-    )
+  const images = await getImageMetadata(k8s)
+  const namespaces = Object.keys(images)
+  return namespaces.reduce((acc, namespace) => {
+    const resources = images[namespace]
+    resources.daemonSets.forEach(testResource(acc))
+    resources.deployments.forEach(testResource(acc))
+    resources.statefulSets.forEach(testResource(acc))
+    return acc
+  }, [])
 }
 
-function getContainer (k8s, resources) {
+async function getContainer (k8s, resources) {
   if (resources.daemonSet) {
     log.info(`    creating daemonSet '${resources.daemonSet.metadata.name}'`)
-    return k8s.createDaemonSet(resources.daemonSet)
+    await k8s.createDaemonSet(resources.daemonSet)
   } else if (resources.deployment) {
     log.info(`    creating deployment '${resources.deployment.metadata.name}'`)
-    return k8s.createDeployment(resources.deployment)
+    await k8s.createDeployment(resources.deployment)
   } else if (resources.statefulSet) {
     log.info(`    creating statefulSet '${resources.statefulSet.metadata.name}'`)
-    return k8s.createStatefulSet(resources.statefulSet)
+    await k8s.createStatefulSet(resources.statefulSet)
   } else if (resources.cronJob) {
     log.info(`    creating cronJob '${resources.cronJob.metadata.name}'`)
-    return k8s.createCronJob(resources.cronJob)
+    await k8s.createCronJob(resources.cronJob)
   } else if (resources.job) {
     log.info(`    creating job '${resources.job.metadata.name}'`)
-    return k8s.createJob(resources.job)
+    await k8s.createJob(resources.job)
   } else {
     const manifest = _.find(
       _.values(resources),
@@ -370,9 +306,7 @@ function getContainer (k8s, resources) {
     if (manifest) {
       const kind = manifest.kind.toLowerCase()
       log.info(`    creating ${kind} '${manifest.metadata.name}'`)
-      return k8s.createManifest(manifest)
-    } else {
-      return Promise.resolve()
+      await k8s.createManifest(manifest)
     }
   }
 }
@@ -397,51 +331,37 @@ function getContainerSpec (resources) {
   }
 }
 
-function getImageMetadata (k8s, options) {
-  return k8s.listNamespaces()
-    .then(
-      namespaces => {
-        return Promise.reduce(namespaces, (acc, namespace) => {
-          return getImageMetadataForNamespace(k8s, namespace, options)
-            .then(
-              result => {
-                acc[result.namespace] = result
-                return acc
-              },
-              err => {
-                log.error(`Failed to get image metadata for namespace '${namespace}':\n\t${err.stack}'`)
-              }
-            )
-        }, {})
-      },
-      err => {
-        log.error(`Failed to get image metadata - error while retrieving namespace list:\n\t${err.message}`)
-        throw err
-      }
-    )
+async function getImageMetadata (k8s, options) {
+  const namespaces = await k8s.listNamespaces()
+    .catch(err => {
+      log.error(`Failed to get image metadata - error while retrieving namespace list:\n\t${err.message}`)
+      throw err
+    })
+  return Promise.reduce(namespaces, async (acc, namespace) => {
+    const result = await getImageMetadataForNamespace(k8s, namespace, options)
+      .catch(err => {
+        log.error(`Failed to get image metadata for namespace '${namespace}':\n\t${err.stack}'`)
+      })
+
+    acc[result.namespace] = result
+    return acc
+  }, {})
 }
 
-function getImageMetadataForNamespace (k8s, namespace, options = {}) {
-  let getDeployments = () => k8s.getDeploymentsByNamespace(namespace, options.baseImage)
-  let getDaemons = () => k8s.getDaemonSetsByNamespace(namespace, options.baseImage)
-  let getStateful = () => k8s.getStatefulSetsByNamespace(namespace, options.baseImage)
-
-  return join(
-    getDeployments(),
-    getDaemons(),
-    getStateful(),
-    (deployments, daemons, sets) => {
-      const merged = Object.assign({}, deployments, daemons, sets)
-      return merged
-    }
-  )
+async function getImageMetadataForNamespace (k8s, namespace, options = {}) {
+  const [deployments, daemons, sets] = await Promise.all([
+    k8s.getDeploymentsByNamespace(namespace, options.baseImage),
+    k8s.getDaemonSetsByNamespace(namespace, options.baseImage),
+    k8s.getStatefulSetsByNamespace(namespace, options.baseImage)
+  ])
+  return Object.assign({}, deployments, daemons, sets)
 }
 
-function getNamespaces (k8s) {
-  return k8s.listNamespaces()
+async function getNamespaces (k8s) {
+  await k8s.listNamespaces()
 }
 
-function getUpgradeCandidates (k8s, image, options = {filter: ['imageName', 'imageOwner', 'owner', 'repo', 'branch']}) {
+async function getUpgradeCandidates (k8s, image, options = {filter: ['imageName', 'imageOwner', 'owner', 'repo', 'branch']}) {
   if (!options.filter || options.filter.length === 0) {
     throw new Error(`hikaru was given an upgrade command with image '${image} and no filter which would result in forcing all resources to the same image. This command would certainly destroy the cluster and is refused.`)
   }
@@ -449,22 +369,18 @@ function getUpgradeCandidates (k8s, image, options = {filter: ['imageName', 'ima
   let filter = _.pick(sourceMeta, options.filter)
   filter = _.pickBy(filter, _.identity)
   log.info(`identifying candidates for ${image} with filter fields '[${options.filter.join(', ')}]' for resources matching: ${JSON.stringify(filter)}`)
-  return findResourcesByMetadata(k8s, filter)
-    .then(
-      list => {
-        return list.reduce((acc, resource) => {
-          const diff = compare(resource.image, image)
-          resource.diff = diff
-          resource.comparedTo = image
-          if (acc[diff]) {
-            acc[diff].push(resource)
-          } else {
-            acc.error.push(resource)
-          }
-          return acc
-        }, {upgrade: [], obsolete: [], equal: [], error: []})
-      }
-    )
+  const list = await findResourcesByMetadata(k8s, filter)
+  return list.reduce((acc, resource) => {
+    const diff = compare(resource.image, image)
+    resource.diff = diff
+    resource.comparedTo = image
+    if (acc[diff]) {
+      acc[diff].push(resource)
+    } else {
+      acc.error.push(resource)
+    }
+    return acc
+  }, {upgrade: [], obsolete: [], equal: [], error: []})
 }
 
 function match (target, props, options = {}) {
@@ -487,11 +403,9 @@ function onAccountCreationFailed (account, err) {
   throw err
 }
 
-function onAccountCreated (k8s, resources) {
-  return createRole(k8s, resources)
-    .then(
-      onRoleCreated.bind(null, k8s, resources)
-    )
+async function onAccountCreated (k8s, resources) {
+  await createRole(k8s, resources)
+  await onRoleCreated(k8s, resources)
 }
 
 function onAccountDeletionFailed (account, err) {
@@ -499,16 +413,14 @@ function onAccountDeletionFailed (account, err) {
   throw err
 }
 
-function onAccountDeleted (k8s, resources) {
-  return deleteRoleBinding(k8s, resources)
-    .then(
-      onRoleBindingDeleted.bind(null, k8s, resources)
-    )
+async function onAccountDeleted (k8s, resources) {
+  await deleteRoleBinding(k8s, resources)
+  await onRoleBindingDeleted(k8s, resources)
 }
 
-function onConfigurationCreated (k8s, cluster) {
+async function onConfigurationCreated (k8s, cluster) {
   log.info('configuration maps created')
-  return createLevels(k8s, cluster)
+  await createLevels(k8s, cluster)
     .then(
       () => log.info('cluster initialization complete'),
       onResourcesFailed
@@ -562,28 +474,27 @@ function onContainerServiceCreated (k8s, resources) {
 }
 
 function onDeletionFailed (err) {
-  log.error(`Failed to erase cluster resources with error:\n\t${err.message}`)
+  log.error(`Failed to erase cluster resources with error:\n\t${err.stack}`)
   throw err
 }
 
-function onNamespacesCreated (k8s, cluster) {
+async function onNamespacesCreated (k8s, cluster) {
   log.info('namespaces created')
-  return createConfiguration(k8s, cluster)
-    .then(
-      onConfigurationCreated.bind(null, k8s, cluster),
-      onConfigurationCreationFailed.bind(null, cluster)
-    )
+  await createConfiguration(k8s, cluster)
+    .catch(onConfigurationCreationFailed.bind(null, cluster))
     .catch(exitOnError)
+
+  await onConfigurationCreated(k8s, cluster)
 }
 
-function onNamespacesDeleted (k8s, cluster) {
+async function onNamespacesDeleted (k8s, cluster) {
   log.info('namespaces deleted')
-  return deleteConfiguration(k8s, cluster)
-    .then(
-      onConfigurationDeleted.bind(null, k8s, cluster),
+  await deleteConfiguration(k8s, cluster)
+    .catch(
       onConfigurationDeletionFailed.bind(null, cluster)
     )
     .catch(exitOnError)
+  await onConfigurationDeleted(k8s, cluster)
 }
 
 function onNamespaceCreationFailed (cluster, err) {
@@ -615,11 +526,9 @@ function onRoleCreated (k8s, resources) {
   return createRoleBinding(k8s, resources)
 }
 
-function onRoleDeleted (k8s, resources) {
-  return deleteContainer(k8s, resources)
-    .then(
-      onContainerDeleted.bind(null, k8s, resources)
-    )
+async function onRoleDeleted (k8s, resources) {
+  await deleteContainer(k8s, resources)
+  await onContainerDeleted(k8s, resources)
 }
 
 function onRoleCreationFailed (role, err) {
@@ -632,11 +541,9 @@ function onRoleDeletionFailed (role, err) {
   throw err
 }
 
-function onRoleBindingDeleted (k8s, resources) {
-  return deleteRole(k8s, resources)
-    .then(
-      onRoleDeleted.bind(null, k8s, resources)
-    )
+async function onRoleBindingDeleted (k8s, resources) {
+  await deleteRole(k8s, resources)
+  await onRoleDeleted(k8s, resources)
 }
 
 function onRoleBindingCreationFailed (binding, err) {
@@ -659,93 +566,79 @@ function onServiceDeletionFailed (service, err) {
   throw err
 }
 
-function removeCluster (k8s, cluster) {
-  return deleteNamespaces(k8s, cluster)
-    .then(
-      onNamespacesDeleted.bind(null, k8s, cluster),
+async function removeCluster (k8s, cluster) {
+  await deleteNamespaces(k8s, cluster)
+    .catch(
       onNamespaceDeletionFailed.bind(null, cluster)
     )
+  await onNamespacesDeleted(k8s, cluster)
 }
 
-function removeContainer (k8s, resources) {
+async function removeContainer (k8s, resources) {
   if (resources.daemonSet) {
     log.info(`    deleting daemonSet '${resources.daemonSet.metadata.name}'`)
-    return k8s.deleteDaemonSet(resources.daemonSet.metadata.namespace, resources.daemonSet.metadata.name)
+    await k8s.deleteDaemonSet(resources.daemonSet.metadata.namespace, resources.daemonSet.metadata.name)
   } else if (resources.deployment) {
     log.info(`    deleting deployment '${resources.deployment.metadata.name}'`)
-    return k8s.deleteDeployment(resources.deployment.metadata.namespace, resources.deployment.metadata.name)
+    await k8s.deleteDeployment(resources.deployment.metadata.namespace, resources.deployment.metadata.name)
   } else if (resources.statefulSet) {
     log.info(`    deleting statefulSet '${resources.statefulSet.metadata.name}'`)
-    return k8s.deleteStatefulSet(resources.statefulSet.metadata.namespace, resources.statefulSet.metadata.name)
+    await k8s.deleteStatefulSet(resources.statefulSet.metadata.namespace, resources.statefulSet.metadata.name)
   } else if (resources.cronJob) {
     log.info(`    deleting cronJob '${resources.cronJob.metadata.name}'`)
-    return k8s.deleteCronJob(resources.cronJob.metadata.namespace, resources.cronJob.metadata.name)
+    await k8s.deleteCronJob(resources.cronJob.metadata.namespace, resources.cronJob.metadata.name)
   } else if (resources.job) {
     log.info(`    deleting job '${resources.job.metadata.name}'`)
-    return k8s.deleteJob(resources.job.metadata.namespace, resources.job.metadata.name)
+    await k8s.deleteJob(resources.job.metadata.namespace, resources.job.metadata.name)
   }
 }
 
-function runJob (k8s, cluster, namespace, jobName) {
+async function runJob (k8s, cluster, namespace, jobName) {
   const fullName = `${jobName}.${namespace}`
   const jobSpec = cluster.services[fullName]
   if (!jobSpec) {
-    return Promise.reject(new Error(`no job '${jobName}' in namespace '${namespace}', please check the specification and spelling`))
+    throw new Error(`no job '${jobName}' in namespace '${namespace}', please check the specification and spelling`)
   }
   log.info(`creating job prerequisites: '${namespace}'`)
-  const steps = [
-    () => k8s.createNamespace(namespace),
-    () => k8s.fixNamespaceLabels(),
-    () => createConfiguration(k8s, cluster),
-    () => createAccount(k8s, jobSpec),
-    () => createNetworkPolicy(k8s, jobSpec)
-  ]
+  try {
+    await k8s.createNamespace(namespace)
+    await k8s.fixNamespaceLabels()
+    await createConfiguration(k8s, cluster)
+    await createAccount(k8s, jobSpec)
+    await createNetworkPolicy(k8s, jobSpec)
+  } catch (err) {
+    log.error(`failed to establish namespace '${namespace}' - cannot run job '${jobName}': ${err.stack}`)
+    throw new Error(`cannot run job '${jobName}' - could not establish '${namespace}: ${err.stack}'`)
+  }
 
-  return Promise.mapSeries(steps, s => s())
-    .then(
-      () => k8s.runJob(namespace, jobName, jobSpec.job)
-        .then(
-          null,
-          err => {
-            log.error(`failed to run job '${jobName}' in '${namespace}': ${err.stack}`)
-            throw err
-          }
-        ),
-      err => {
-        log.error(`failed to establish namespace '${namespace}' - cannot run job '${jobName}': ${err.stack}`)
-        throw new Error(`cannot run job '${jobName}' - could not establish '${namespace}: ${err.stack}'`)
-      }
-    )
+  await k8s.runJob(namespace, jobName, jobSpec.job)
+    .catch(err => {
+      log.error(`failed to run job '${jobName}' in '${namespace}': ${err.stack}`)
+      throw err
+    })
 }
 
-function upgradeResources (k8s, image, options) {
-  return getUpgradeCandidates(k8s, image, options)
-    .then(
-      set => {
-        const upgrades = set.upgrade.map(upgradeResource.bind(null, k8s))
-        return Promise
-          .all(upgrades)
-          .then(
-            () => set
-          )
-      },
-      err => {
-        log.error(`Upgrade process for '${image}' failed with error:\n\t${err.message}`)
-      }
-    )
+async function upgradeResources (k8s, image, options) {
+  const set = await getUpgradeCandidates(k8s, image, options)
+    .catch(err => {
+      log.error(`Upgrade process for '${image}' failed with error:\n\t${err.message}`)
+    })
+  const upgrades = set.upgrade.map(upgradeResource.bind(null, k8s))
+  await Promise.all(upgrades)
+  return set
 }
 
-function upgradeResource (k8s, metadata) {
+async function upgradeResource (k8s, metadata) {
   const namespace = metadata.namespace
   const name = metadata.service
   const container = metadata.container
   const image = metadata.comparedTo
   if (/daemonset/i.test(metadata.type)) {
-    return k8s.updateDaemonSet(namespace, name, image, container)
+    await k8s.updateDaemonSet(namespace, name, image, container)
   } else if (/deployment/i.test(metadata.type)) {
-    return k8s.upgradeDeployment(namespace, name, image, container)
+    await k8s.upgradeDeployment(namespace, name, image, container)
   } else if (/statefulset/i.test(metadata.type)) {
-    return k8s.upgradeStatefulSet(namespace, name, image, container)
+    await k8s.upgradeStatefulSet(namespace, name, image, container)
   }
 }
 

--- a/src/cluster.js
+++ b/src/cluster.js
@@ -516,9 +516,10 @@ async function removeCluster (k8s, cluster) {
     .catch(exitOnError)
   log.info('configuration maps deleted')
 
-  return deleteLevels(k8s, cluster)
+  await deleteLevels(k8s, cluster)
     .catch(onDeletionFailed)
     .catch(exitOnError)
+
   log.info('cluster deletion complete')
 }
 

--- a/src/commands/deploy.js
+++ b/src/commands/deploy.js
@@ -122,7 +122,7 @@ function handle (config, hikaru, readFile, aliasCache, debugOut, argv) {
   hikaru.deployCluster(argv.source, options)
     .catch(async err => {
       if (!err.tokens) {
-        console.error(`There was a problem in the specification at '${argv.source}'.\n ${err}`)
+        console.error(`There was a problem in the specification at '${argv.source}'.\n ${err.stack}`)
         process.exit(100)
       }
       console.log(`${err.tokens.length} tokens were found in the specification. When prompted, please provide a value for each.`)

--- a/src/commands/deploy.js
+++ b/src/commands/deploy.js
@@ -120,30 +120,25 @@ function handle (config, hikaru, readFile, aliasCache, debugOut, argv) {
   })
 
   hikaru.deployCluster(argv.source, options)
-    .then(
-      () => console.log('done'),
-      err => {
-        if (err.tokens) {
-          console.log(`${err.tokens.length} tokens were found in the specification. When prompted, please provide a value for each.`)
-          return inquire.acquireTokens(err.tokens)
-            .then(
-              tokens => {
-                if (options.data !== undefined) {
-                  options.data = Object.assign(options.data, tokens)
-                } else {
-                  options.data = tokens
-                }
-                return hikaru.deployCluster(err.specPath, {
-                  data: options.data
-                })
-              }
-            )
-        } else {
-          console.error(`There was a problem in the specification at '${argv.source}'.\n ${err}`)
-          process.exit(100)
-        }
+    .catch(async err => {
+      if (!err.tokens) {
+        console.error(`There was a problem in the specification at '${argv.source}'.\n ${err}`)
+        process.exit(100)
       }
-    )
+      console.log(`${err.tokens.length} tokens were found in the specification. When prompted, please provide a value for each.`)
+      const tokens = await inquire.acquireTokens(err.tokens)
+      if (options.data !== undefined) {
+        options.data = Object.assign(options.data, tokens)
+      } else {
+        options.data = tokens
+      }
+      return hikaru.deployCluster(err.specPath, Object.assign(
+        {},
+        options,
+        {data: options.data}
+      ))
+    })
+  console.log('done')
 }
 
 module.exports = function (config, hikaru, readFile, aliasCache, debugOut) {

--- a/src/commands/deploy.js
+++ b/src/commands/deploy.js
@@ -68,7 +68,7 @@ function build (config, aliasCache) {
   }
 }
 
-function handle (config, hikaru, readFile, aliasCache, debugOut, argv) {
+async function handle (config, hikaru, readFile, aliasCache, debugOut, argv) {
   if (argv.ca) {
     config.ca = readFile(argv.ca)
   }
@@ -119,7 +119,7 @@ function handle (config, hikaru, readFile, aliasCache, debugOut, argv) {
     stream: debugOut
   })
 
-  hikaru.deployCluster(argv.source, options)
+  await hikaru.deployCluster(argv.source, options)
     .catch(async err => {
       if (!err.tokens) {
         console.error(`There was a problem in the specification at '${argv.source}'.\n ${err.stack}`)

--- a/src/commands/remove.js
+++ b/src/commands/remove.js
@@ -56,7 +56,7 @@ function build (config, aliasCache) {
   }
 }
 
-function handle (config, hikaru, readFile, aliasCache, debugOut, argv) {
+async function handle (config, hikaru, readFile, aliasCache, debugOut, argv) {
   if (argv.ca) {
     config.ca = readFile(argv.ca)
   }
@@ -102,7 +102,7 @@ function handle (config, hikaru, readFile, aliasCache, debugOut, argv) {
     stream: debugOut
   })
 
-  hikaru.removeCluster(argv.source, options)
+  await hikaru.removeCluster(argv.source, options)
     .catch(async err => {
       if (!err.tokens) {
         console.error(`There was a problem in the specification at '${argv.source}'.\n ${err.stack}`)

--- a/src/commands/remove.js
+++ b/src/commands/remove.js
@@ -105,7 +105,7 @@ function handle (config, hikaru, readFile, aliasCache, debugOut, argv) {
   hikaru.removeCluster(argv.source, options)
     .catch(async err => {
       if (!err.tokens) {
-        console.error(`There was a problem in the specification at '${argv.source}'.\n ${err}`)
+        console.error(`There was a problem in the specification at '${argv.source}'.\n ${err.stack}`)
         process.exit(100)
       }
       console.log(`${err.tokens.length} tokens were found in the specification. When prompted, please provide a value for each.`)

--- a/src/connection.js
+++ b/src/connection.js
@@ -1,7 +1,7 @@
 const K8sClient = require('auto-kubernetes-client')
 const log = require('bole')('connection')
 
-function getClient (config) {
+async function getClient (config) {
   validate(config)
   const connection = {
     url: config.url
@@ -56,18 +56,15 @@ function getClient (config) {
   }
 
   log.debug(`connecting to '${connection.url}' ...`)
-  return K8sClient(connection)
-    .then(
-      client => {
-        client.version = config.version
-        client.saveDiffs = config.saveDiffs
-        return client
-      },
-      err => {
-        log.error(`could not connect to '${connection.url}':\n\t${err.message}`)
-        throw new Error(`failed to connect to Kubernetes cluster '${config.url}' with ${creds}:\n\t'${err.message}'`)
-      }
-    )
+  try {
+    var client = await K8sClient(connection)
+  } catch (err) {
+    log.error(`could not connect to '${connection.url}':\n\t${err.message}`)
+    throw new Error(`failed to connect to Kubernetes cluster '${config.url}' with ${creds}:\n\t'${err.message}'`)
+  }
+  client.version = config.version
+  client.saveDiffs = config.saveDiffs
+  return client
 }
 
 function validate (config) {

--- a/src/index.js
+++ b/src/index.js
@@ -6,13 +6,12 @@ const _ = require('lodash')
 
 fount.register('cluster', require('./cluster'))
 fount.register('k8s', require('./k8s'))
-fount.register('client', async (config) => {
-  const client = await connection.getClient(config)
+fount.register('client', config => {
+  return connection.getClient(config)
     .catch(err => {
       log.error(err.message)
       return null
     })
-  return client
 })
 fount.register('config', require('./config')())
 

--- a/src/k8s/cronJob.js
+++ b/src/k8s/cronJob.js
@@ -1,7 +1,8 @@
 const _ = require('lodash')
 const log = require('bole')('k8s')
-const Promise = require('bluebird')
 const diffs = require('./specDiff')
+
+const delay = ms => new Promise(resolve => setTimeout(resolve, ms))
 
 const GROUPS = {
   '1.7': 'batch/v2alpha1',
@@ -26,163 +27,122 @@ function multiple (client, namespace) {
   return base(client, namespace).cronjobs
 }
 
-function checkCronJob (client, namespace, name, outcome, resolve, reject, wait) {
-  let ms = wait || 500
-  let next = ms + (ms / 2)
-  if (next > 5000) {
-    next = 5000
-  }
-  setTimeout(() => {
+async function checkCronJob (client, namespace, name, outcome, wait = 500) {
+  let tries = 0
+  do {
+    wait *= 1.5
+    if (wait > 5000) {
+      wait = 5000
+    }
+    tries++
+    await delay(wait)
     log.debug(`checking cron job status '${namespace}.${name}' for '${outcome}'`)
-    single(client, namespace, name).get()
-      .then(
-        result => {
-          try {
-            log.debug(`cron job '${namespace}.${name}' status - '${JSON.stringify(result.status, null, 2)}'`)
-            const status = result.status.conditions && result.status.conditions.length
-                              ? result.status.conditions[0] : {}
-            if (outcome === 'completion') {
-              if (result.status === undefined || Object.keys(result.status).length === 0) {
-                log.info(`cron job appears to have created successfully but did not run (according to schedule)`)
-                resolve(result)
-              } else if (status.type === 'Complete' && status.status === 'True') {
-                resolve(result)
-              } else if (status.type === 'Failed' && status.status === 'True') {
-                reject(new Error(`CronJob '${namespace}.${name}' failed to complete with status: '${JSON.stringify(result.status, null, 2)}'`))
-              } else {
-                checkCronJob(client, namespace, name, outcome, resolve, reject, next)
-              }
-            } else if (outcome === 'updated') {
-              if (result.status === undefined || Object.keys(result.status).length === 0) {
-                log.info(`cron job appears to have updated successfully but did not run (according to schedule)`)
-                resolve(result)
-              } else if (status.type === 'Complete' && status.status === 'True') {
-                resolve(result)
-              } else if (status.type === 'Failed' && status.status === 'True') {
-                reject(new Error(`CronJob '${namespace}.${name}' failed to update with status: '${JSON.stringify(result.status, null, 2)}'`))
-              } else {
-                checkCronJob(client, namespace, name, outcome, resolve, reject, next)
-              }
-            } else {
-              checkCronJob(client, namespace, name, outcome, resolve, reject, next)
-            }
-          } catch (e) {
-            log.error(`error checking result '${JSON.stringify(result, null, 2)}':\n\t${e}`)
-          }
-        },
-        () => {
-          if (outcome === 'deletion') {
-            log.debug(`cron job '${namespace}.${name}' deleted successfully.`)
-            resolve()
-          } else {
-            log.debug(`cron job '${namespace}.${name}' status check got API error. Checking again in ${next} ms.`)
-            checkCronJob(client, namespace, name, outcome, resolve, reject, next)
-          }
+    try {
+      var result = await single(client, namespace, name).get()
+    } catch (err) {
+      if (outcome === 'deletion') {
+        log.debug(`cron job '${namespace}.${name}' deleted successfully.`)
+        return result
+      } else {
+        log.debug(`cron job '${namespace}.${name}' status check got API error. Checking again in ${wait} ms.`)
+        continue
+      }
+    }
+
+    try {
+      log.debug(`cron job '${namespace}.${name}' status - '${JSON.stringify(result.status, null, 2)}'`)
+      const status = result.status.conditions && result.status.conditions.length
+                        ? result.status.conditions[0] : {}
+      if (outcome === 'completion') {
+        if (result.status === undefined || Object.keys(result.status).length === 0) {
+          log.info(`cron job appears to have created successfully but did not run (according to schedule)`)
+          return result
+        } else if (status.type === 'Complete' && status.status === 'True') {
+          return result
+        } else if (status.type === 'Failed' && status.status === 'True') {
+          throw new Error(`CronJob '${namespace}.${name}' failed to complete with status: '${JSON.stringify(result.status, null, 2)}'`)
         }
-      )
-  }, ms)
+      } else if (outcome === 'updated') {
+        if (result.status === undefined || Object.keys(result.status).length === 0) {
+          log.info(`cron job appears to have updated successfully but did not run (according to schedule)`)
+          return result
+        } else if (status.type === 'Complete' && status.status === 'True') {
+          return result
+        } else if (status.type === 'Failed' && status.status === 'True') {
+          throw new Error(`CronJob '${namespace}.${name}' failed to update with status: '${JSON.stringify(result.status, null, 2)}'`)
+        }
+      }
+    } catch (e) {
+      log.error(`error checking result '${JSON.stringify(result, null, 2)}':\n\t${e}`)
+    }
+  } while (tries < 20)
 }
 
-function createCronJob (client, deletes, jobSpec) {
+async function createCronJob (client, deletes, jobSpec) {
   const namespace = jobSpec.metadata.namespace || 'default'
   const name = jobSpec.metadata.name
-  let create = (resolve, reject) =>
-    multiple(client, namespace).create(jobSpec)
-    .then(
-      result => {
-        checkCronJob(client, namespace, name, 'completion', resolve, reject)
-      },
-      err => {
-        reject(new Error(`Cron Job '${namespace}.${name}' failed to create:\n\t${err.message}`))
+
+  const create = async () => {
+    await multiple(client, namespace).create(jobSpec)
+      .catch(err => {
+        throw new Error(`Cron Job '${namespace}.${name}' failed to create:\n\t${err.message}`)
+      })
+    await checkCronJob(client, namespace, name, 'completion')
+  }
+
+  try {
+    var loaded = await single(client, namespace, name).get()
+  } catch (err) {
+    return create()
+  }
+
+  const diff = diffs.simple(loaded, jobSpec)
+  if (!_.isEmpty(diff)) {
+    if (diffs.canPatch(diff, 'job') || diffs.isBackoffOnly(diff, jobSpec)) {
+      if (client.saveDiffs) {
+        diffs.save(loaded, jobSpec, diff)
       }
-    )
-  return new Promise((resolve, reject) => {
-    single(client, namespace, name).get()
-      .then(
-        loaded => {
-          const diff = diffs.simple(loaded, jobSpec)
-          if (_.isEmpty(diff)) {
-            resolve()
-          } else {
-            if (diffs.canPatch(diff, 'job') || diffs.isBackoffOnly(diff, jobSpec)) {
-              if (client.saveDiffs) {
-                diffs.save(loaded, jobSpec, diff)
-              }
-              updateCronJob(client, namespace, name, diff)
-                .then(
-                  resolve,
-                  reject
-                )
-            } else if (diffs.canReplace(diff, 'job')) {
-              replaceCronJob(client, namespace, name, jobSpec)
-                .then(
-                  resolve,
-                  reject
-                )
-            } else {
-              deleteCronJob(client, namespace, name)
-                .then(
-                  create.bind(null, resolve, reject),
-                  reject
-                )
-            }
-          }
-        },
-        create.bind(null, resolve, reject)
-      )
-  })
+      return updateCronJob(client, namespace, name, diff)
+    } else if (diffs.canReplace(diff, 'job')) {
+      return replaceCronJob(client, namespace, name, jobSpec)
+    } else {
+      await deleteCronJob(client, namespace, name)
+      return create()
+    }
+  }
 }
 
-function deleteCronJob (client, namespace, name) {
-  return new Promise((resolve, reject) => {
-    single(client, namespace, name).get()
-      .then(
-        () => {
-          single(client, namespace, name).delete()
-            .then(
-              result => {
-                checkCronJob(client, namespace, name, 'deletion', resolve)
-              },
-              err => {
-                reject(new Error(`Job '${namespace}.${name}' could not be deleted:\n\t${err.message}`))
-              }
-            )
-        },
-        () => { resolve() }
-      )
-  })
+async function deleteCronJob (client, namespace, name) {
+  try {
+    await single(client, namespace, name).get()
+  } catch (err) {
+    return
+  }
+  single(client, namespace, name).delete()
+    .catch(err => {
+      throw new Error(`Job '${namespace}.${name}' could not be deleted:\n\t${err.message}`)
+    })
+  await checkCronJob(client, namespace, name, 'deletion')
 }
 
-function listCronJobs (client, namespace) {
+async function listCronJobs (client, namespace) {
   return multiple(client, namespace).list()
 }
 
-function replaceCronJob (client, namespace, name, spec) {
-  return new Promise((resolve, reject) => {
-    single(client, namespace, name).update(spec)
-      .then(
-        result => {
-          checkCronJob(client, namespace, name, 'updated', resolve)
-        },
-        err => {
-          reject(new Error(`CronJob '${namespace}.${name}' failed to replace:\n\t${err.message}`))
-        }
-      )
-  })
+async function replaceCronJob (client, namespace, name, spec) {
+  await single(client, namespace, name).update(spec)
+    .catch(err => {
+      throw new Error(`CronJob '${namespace}.${name}' failed to replace:\n\t${err.message}`)
+    })
+  await checkCronJob(client, namespace, name, 'updated')
 }
 
-function updateCronJob (client, namespace, name, diff) {
-  return new Promise((resolve, reject) => {
-    single(client, namespace, name).patch(diff)
-      .then(
-        result => {
-          checkCronJob(client, namespace, name, 'updated', resolve)
-        },
-        err => {
-          reject(new Error(`CronJob '${namespace}.${name}' failed to update:\n\t${err.message}`))
-        }
-      )
-  })
+async function updateCronJob (client, namespace, name, diff) {
+  await single(client, namespace, name).patch(diff)
+    .catch(err => {
+      throw new Error(`CronJob '${namespace}.${name}' failed to update:\n\t${err.message}`)
+    })
+  await checkCronJob(client, namespace, name, 'updated')
 }
 
 module.exports = function (client, deletes) {

--- a/src/k8s/cronJob.js
+++ b/src/k8s/cronJob.js
@@ -30,12 +30,13 @@ function multiple (client, namespace) {
 async function checkCronJob (client, namespace, name, outcome, wait = 500) {
   let tries = 0
   do {
+    await delay(wait)
     wait *= 1.5
     if (wait > 5000) {
       wait = 5000
     }
     tries++
-    await delay(wait)
+
     log.debug(`checking cron job status '${namespace}.${name}' for '${outcome}'`)
     try {
       var result = await single(client, namespace, name).get()

--- a/src/k8s/cronJob.js
+++ b/src/k8s/cronJob.js
@@ -37,7 +37,7 @@ async function checkCronJob (client, namespace, name, outcome) {
         return result
       } else {
         log.debug(`cron job '${namespace}.${name}' status check got API error. Checking again in soon.`)
-        throw new Error('continue')
+        throw new Error('cron job not ready yet')
       }
     }
 
@@ -67,7 +67,7 @@ async function checkCronJob (client, namespace, name, outcome) {
     } catch (e) {
       log.error(`error checking result '${JSON.stringify(result, null, 2)}':\n\t${e}`)
     }
-    throw new Error('continue')
+    throw new Error('cron job not ready yet')
   })
 }
 

--- a/src/k8s/cronJob.js
+++ b/src/k8s/cronJob.js
@@ -27,7 +27,7 @@ function multiple (client, namespace) {
 }
 
 async function checkCronJob (client, namespace, name, outcome) {
-  retry(async bail => {
+  return retry(async bail => {
     log.debug(`checking cron job status '${namespace}.${name}' for '${outcome}'`)
     try {
       var result = await single(client, namespace, name).get()

--- a/src/k8s/cronJob.js
+++ b/src/k8s/cronJob.js
@@ -36,7 +36,7 @@ async function checkCronJob (client, namespace, name, outcome) {
         log.debug(`cron job '${namespace}.${name}' deleted successfully.`)
         return result
       } else {
-        log.debug(`cron job '${namespace}.${name}' status check got API error. Checking again in soon.`)
+        log.debug(`cron job '${namespace}.${name}' status check got API error. Checking again soon.`)
         throw new Error('cron job not ready yet')
       }
     }

--- a/src/k8s/cronJob.js
+++ b/src/k8s/cronJob.js
@@ -111,7 +111,7 @@ async function deleteCronJob (client, namespace, name) {
   } catch (err) {
     return
   }
-  single(client, namespace, name).delete()
+  await single(client, namespace, name).delete()
     .catch(err => {
       throw new Error(`Job '${namespace}.${name}' could not be deleted:\n\t${err.message}`)
     })

--- a/src/k8s/daemonSet.js
+++ b/src/k8s/daemonSet.js
@@ -5,6 +5,8 @@ const core = require('./core')
 const diffs = require('./specDiff')
 const parse = require('../imageParser').parse
 
+const delay = ms => new Promise(resolve => setTimeout(resolve, ms))
+
 const GROUPS = {
   '1.4': 'extensions/v1beta1',
   '1.5': 'extensions/v1beta1',
@@ -31,185 +33,138 @@ function multiple (client, namespace, name) {
   return base(client, namespace).daemonsets
 }
 
-function checkDaemonSet (client, namespace, name, outcome, resolve, wait) {
-  let ms = wait || 500
-  let next = ms + (ms / 2)
-  if (next > 5000) {
-    next = 5000
-  }
-  setTimeout(() => {
+async function checkDaemonSet (client, namespace, name, outcome, wait = 500) {
+  let tries = 0
+  do {
+    await delay(wait)
+    wait *= 1.5
+    if (wait > 5000) {
+      wait = 5000
+    }
+    tries++
+
     log.debug(`checking daemonSet status '${namespace}.${name}' for '${outcome}'`)
-    single(client, namespace, name).get()
-      .then(
-        result => {
-          log.debug(`daemonSet '${namespace}.${name}' status - '${JSON.stringify(result.status, null, 2)}'`)
-          if ((outcome === 'creation' || outcome === 'update') && result.status.numberReady === result.status.desiredNumberScheduled) {
-            resolve(result)
-          } else if (outcome === 'deletion' && result.status.phase !== 'Terminating') {
-            resolve(result)
-          } else {
-            checkDaemonSet(client, namespace, name, outcome, resolve, next)
-          }
-        },
-        () => {
-          if (outcome === 'deletion') {
-            log.debug(`daemonSet '${namespace}.${name}' deleted successfully.`)
-            resolve()
-          } else {
-            log.debug(`daemonSet '${namespace}.${name}' status check got API error. Checking again in ${next} ms.`)
-            checkDaemonSet(client, namespace, name, outcome, resolve, next)
-          }
-        }
-      )
-  }, ms)
+    try {
+      var result = await single(client, namespace, name).get()
+    } catch (err) {
+      if (outcome === 'deletion') {
+        log.debug(`daemonSet '${namespace}.${name}' deleted successfully.`)
+        return
+      } else {
+        log.debug(`daemonSet '${namespace}.${name}' status check got API error. Checking again in ${wait} ms.`)
+        continue
+      }
+    }
+
+    log.debug(`daemonSet '${namespace}.${name}' status - '${JSON.stringify(result.status, null, 2)}'`)
+    if ((outcome === 'creation' || outcome === 'update') && result.status.numberReady === result.status.desiredNumberScheduled) {
+      return result
+    } else if (outcome === 'deletion' && result.status.phase !== 'Terminating') {
+      return result
+    } else {
+      continue
+    }
+  } while (tries < 20)
 }
 
-function createDaemonSet (client, deletes, daemonSet) {
+async function createDaemonSet (client, deletes, daemonSet) {
   const namespace = daemonSet.metadata.namespace || 'default'
   const name = daemonSet.metadata.name
 
-  let create = (resolve, reject) =>
+  let create = async () => {
     multiple(client, namespace).create(daemonSet)
-    .then(
-      result => {
-        checkDaemonSet(client, namespace, name, 'creation', resolve)
-      },
-      err => {
-        reject(new Error(`DaemonSet '${namespace}.${name}' failed to create:\n\t${err.message}`))
+      .catch(err => {
+        throw new Error(`DaemonSet '${namespace}.${name}' failed to create:\n\t${err.message}`)
+      })
+    return checkDaemonSet(client, namespace, name, 'creation')
+  }
+
+  try {
+    var loaded = await single(client, namespace, name).get()
+  } catch (err) {
+    return create()
+  }
+
+  const diff = diffs.simple(loaded, daemonSet)
+  if (!_.isEmpty(diff)) {
+    if (diffs.canPatch(diff)) {
+      if (client.saveDiffs) {
+        diffs.save(loaded, daemonSet, diff)
       }
-    )
-
-  return new Promise((resolve, reject) => {
-    single(client, namespace, name).get()
-      .then(
-        loaded => {
-          const diff = diffs.simple(loaded, daemonSet)
-          if (_.isEmpty(diff)) {
-            resolve()
-          } else {
-            if (diffs.canPatch(diff)) {
-              if (client.saveDiffs) {
-                diffs.save(loaded, daemonSet, diff)
-              }
-              patchDaemonSet(client, namespace, name, diff)
-                .then(
-                  resolve,
-                  reject
-                )
-            } else if (diffs.canReplace(diff)) {
-              replaceDaemonSet(client, namespace, name, daemonSet)
-                .then(
-                  resolve,
-                  reject
-                )
-            } else {
-              deleteDaemonSet(client, namespace, name)
-                .then(
-                  create.bind(null, resolve, reject),
-                  reject
-                )
-            }
-          }
-        },
-        create.bind(null, resolve, reject)
-      )
-  })
+      await patchDaemonSet(client, namespace, name, diff)
+    } else if (diffs.canReplace(diff)) {
+      await replaceDaemonSet(client, namespace, name, daemonSet)
+    } else {
+      await deleteDaemonSet(client, namespace, name)
+      return create()
+    }
+  }
 }
 
-function deleteDaemonSet (client, namespace, name) {
-  return new Promise((resolve, reject) => {
-    single(client, namespace, name).get()
-      .then(
-        () => {
-          single(client, namespace, name).delete()
-            .then(
-              result => {
-                checkDaemonSet(client, namespace, name, 'deletion', resolve)
-              },
-              err => {
-                reject(new Error(`DaemonSet '${namespace}.${name}' could not be deleted:\n\t${err.message}`))
-              }
-            )
-        },
-        () => {
-          resolve()
-        }
-      )
-  })
+async function deleteDaemonSet (client, namespace, name) {
+  try {
+    await single(client, namespace, name).get()
+  } catch (err) {
+    return
+  }
+  await single(client, namespace, name).delete()
+    .catch(err => {
+      throw new Error(`DaemonSet '${namespace}.${name}' could not be deleted:\n\t${err.message}`)
+    })
+  await checkDaemonSet(client, namespace, name, 'deletion')
 }
 
-function getDaemonSetsByNamespace (client, namespace, baseImage) {
-  return listDaemonSets(client, namespace)
-      .then(
-        list => {
-          let daemonSets = _.reduce(list.items, (acc, spec) => {
-            const containers = core.getContainersFromSpec(spec, baseImage)
-            containers.forEach(container => {
-              const metadata = parse(container.image)
-              acc.push({
-                namespace: namespace,
-                type: 'DaemonSet',
-                service: spec.metadata.name,
-                image: container.image,
-                container: container.name,
-                metadata: metadata,
-                labels: spec.spec.template.metadata
-                  ? spec.spec.template.metadata.labels
-                  : metadata.labels || {}
-              })
-            })
-            return acc
-          }, [])
-          return { namespace, daemonSets }
-        }
-      )
+async function getDaemonSetsByNamespace (client, namespace, baseImage) {
+  const list = await listDaemonSets(client, namespace)
+  let daemonSets = _.reduce(list.items, (acc, spec) => {
+    const containers = core.getContainersFromSpec(spec, baseImage)
+    containers.forEach(container => {
+      const metadata = parse(container.image)
+      acc.push({
+        namespace: namespace,
+        type: 'DaemonSet',
+        service: spec.metadata.name,
+        image: container.image,
+        container: container.name,
+        metadata: metadata,
+        labels: spec.spec.template.metadata
+          ? spec.spec.template.metadata.labels
+          : metadata.labels || {}
+      })
+    })
+    return acc
+  }, [])
+
+  return { namespace, daemonSets }
 }
 
 function listDaemonSets (client, namespace) {
   return multiple(client, namespace).list()
 }
 
-function patchDaemonSet (client, namespace, name, diff) {
-  return new Promise((resolve, reject) => {
-    single(client, namespace, name).patch(diff)
-      .then(
-        result => {
-          checkDaemonSet(client, namespace, name, 'update', resolve)
-        },
-        err => {
-          reject(new Error(`DaemonSet '${namespace}.${name}' failed to patch:\n\t${err.message}`))
-        }
-      )
-  })
+async function patchDaemonSet (client, namespace, name, diff) {
+  await single(client, namespace, name).patch(diff)
+    .catch(err => {
+      throw new Error(`DaemonSet '${namespace}.${name}' failed to patch:\n\t${err.message}`)
+    })
+  await checkDaemonSet(client, namespace, name, 'update')
 }
 
-function replaceDaemonSet (client, namespace, name, spec) {
-  return new Promise((resolve, reject) => {
-    single(client, namespace, name).update(spec)
-      .then(
-        result => {
-          checkDaemonSet(client, namespace, name, 'update', resolve)
-        },
-        err => {
-          reject(new Error(`DaemonSet '${namespace}.${name}' failed to replace:\n\t${err.message}`))
-        }
-      )
-  })
+async function replaceDaemonSet (client, namespace, name, spec) {
+  await single(client, namespace, name).update(spec)
+    .catch(err => {
+      throw new Error(`DaemonSet '${namespace}.${name}' failed to replace:\n\t${err.message}`)
+    })
+  await checkDaemonSet(client, namespace, name, 'update')
 }
 
-function updateDaemonSet (client, namespace, name, image, container) {
+async function updateDaemonSet (client, namespace, name, image, container) {
   const patch = diffs.getImagePatch(container || name, image)
-  return new Promise((resolve, reject) => {
-    single(client, namespace, name).patch(patch)
-      .then(
-        result => {
-          checkDaemonSet(client, namespace, name, 'update', resolve)
-        },
-        err => {
-          reject(new Error(`DaemonSet '${namespace}.${name}' failed to upgrade:\n\t${err.message}`))
-        }
-      )
-  })
+  await single(client, namespace, name).patch(patch)
+    .catch(err => {
+      throw new Error(`DaemonSet '${namespace}.${name}' failed to upgrade:\n\t${err.message}`)
+    })
+  await checkDaemonSet(client, namespace, name, 'update')
 }
 
 module.exports = function (client, deletes) {

--- a/src/k8s/daemonSet.js
+++ b/src/k8s/daemonSet.js
@@ -42,7 +42,7 @@ async function checkDaemonSet (client, namespace, name, outcome) {
         return
       } else {
         log.debug(`daemonSet '${namespace}.${name}' status check got API error. Checking again soon.`)
-        bail(new Error('continue'))
+        bail(new Error('daemon set not ready yet'))
       }
     }
 
@@ -52,7 +52,7 @@ async function checkDaemonSet (client, namespace, name, outcome) {
     } else if (outcome === 'deletion' && result.status.phase !== 'Terminating') {
       return result
     }
-    bail(new Error('continue'))
+    bail(new Error('daemon set not ready yet'))
   })
 }
 

--- a/src/k8s/daemonSet.js
+++ b/src/k8s/daemonSet.js
@@ -32,7 +32,7 @@ function multiple (client, namespace, name) {
 }
 
 async function checkDaemonSet (client, namespace, name, outcome) {
-  retry(async bail => {
+  return retry(async bail => {
     log.debug(`checking daemonSet status '${namespace}.${name}' for '${outcome}'`)
     try {
       var result = await single(client, namespace, name).get()

--- a/src/k8s/daemonSet.js
+++ b/src/k8s/daemonSet.js
@@ -61,7 +61,7 @@ async function createDaemonSet (client, deletes, daemonSet) {
   const name = daemonSet.metadata.name
 
   let create = async () => {
-    multiple(client, namespace).create(daemonSet)
+    await multiple(client, namespace).create(daemonSet)
       .catch(err => {
         throw new Error(`DaemonSet '${namespace}.${name}' failed to create:\n\t${err.message}`)
       })

--- a/src/k8s/daemonSet.js
+++ b/src/k8s/daemonSet.js
@@ -5,7 +5,6 @@ const diffs = require('./specDiff')
 const parse = require('../imageParser').parse
 const retry = require('../retry')
 
-
 const GROUPS = {
   '1.4': 'extensions/v1beta1',
   '1.5': 'extensions/v1beta1',
@@ -32,7 +31,7 @@ function multiple (client, namespace, name) {
   return base(client, namespace).daemonsets
 }
 
-async function checkDaemonSet (client, namespace, name, outcome,) {
+async function checkDaemonSet (client, namespace, name, outcome) {
   retry(async bail => {
     log.debug(`checking daemonSet status '${namespace}.${name}' for '${outcome}'`)
     try {

--- a/src/k8s/deployment.js
+++ b/src/k8s/deployment.js
@@ -1,9 +1,9 @@
 const _ = require('lodash')
 const log = require('bole')('k8s')
-const Promise = require('bluebird')
 const core = require('./core')
 const diffs = require('./specDiff')
 const parse = require('../imageParser').parse
+const retry = require('../retry')
 
 const GROUPS = {
   '1.4': 'extensions/v1beta1',
@@ -31,181 +31,132 @@ function multiple (client, namespace, name) {
   return base(client, namespace).deployments
 }
 
-function checkDeployment (client, namespace, name, outcome, resolve, wait) {
-  let ms = wait || 500
-  let next = ms + (ms / 2)
-  if (next > 5000) {
-    next = 5000
-  }
-  setTimeout(() => {
+async function checkDeployment (client, namespace, name, outcome) {
+  retry(async () => {
     log.debug(`checking deployment status '${namespace}.${name}' for '${outcome}'`)
-    single(client, namespace, name).get()
-      .then(
-        result => {
-          log.debug(`deployment '${namespace}.${name}' status - '${JSON.stringify(result.status, null, 2)}'`)
-          if (outcome === 'creation' && result.status.readyReplicas > 0) {
-            resolve(result)
-          } else if (outcome === 'updated' && result.status.updatedReplicas > 0 && result.status.readyReplicas > 0) {
-            resolve(result)
-          } else if (outcome === 'deletion' && result.status.phase !== 'Terminating') {
-            resolve(result)
-          } else {
-            checkDeployment(client, namespace, name, outcome, resolve, next)
-          }
-        },
-        () => {
-          if (outcome === 'deletion') {
-            log.debug(`deployment '${namespace}.${name}' deleted successfully.`)
-            resolve()
-          } else {
-            log.debug(`deployment '${namespace}.${name}' status check got API error. Checking again in ${next} ms.`)
-            checkDeployment(client, namespace, name, outcome, resolve, next)
-          }
-        }
-      )
-  }, ms)
+    try {
+      var result = await single(client, namespace, name).get()
+    } catch (e) {
+      if (outcome === 'deletion') {
+        log.debug(`deployment '${namespace}.${name}' deleted successfully.`)
+        return
+      } else {
+        log.debug(`deployment '${namespace}.${name}' status check got API error. Checking again...`)
+        throw new Error('continue')
+      }
+    }
+    log.debug(`deployment '${namespace}.${name}' status - '${JSON.stringify(result.status, null, 2)}'`)
+    if (outcome === 'creation' && result.status.readyReplicas > 0) {
+      return result
+    } else if (outcome === 'updated' && result.status.updatedReplicas > 0 && result.status.readyReplicas > 0) {
+      return result
+    } else if (outcome === 'deletion' && result.status.phase !== 'Terminating') {
+      return result
+    } else {
+      throw new Error('continue')
+    }
+  })
 }
 
-function createDeployment (client, deletes, deployment) {
+async function createDeployment (client, deletes, deployment) {
   const kind = deployment.kind.toLowerCase()
   const namespace = deployment.metadata.namespace || 'default'
   const name = deployment.metadata.name
-  let create = (resolve, reject) =>
-    multiple(client, namespace).create(deployment)
-    .then(
-      result => {
-        checkDeployment(client, namespace, name, 'creation', resolve)
-      },
-      err => {
-        reject(new Error(`Deployment '${namespace}.${name}' failed to create:\n\t${err.message}`))
+  let create = async () => {
+    await multiple(client, namespace).create(deployment)
+      .catch(result => {}, err => {
+        throw new Error(`Deployment '${namespace}.${name}' failed to create:\n\t${err.message}`)
+      })
+    await checkDeployment(client, namespace, name, 'creation')
+  }
+
+  try {
+    var loaded = await single(client, namespace, name).get()
+  } catch (e) {
+    return create()
+  }
+  const diff = diffs.simple(loaded, deployment)
+  if (!_.isEmpty(diff)) {
+    if (diffs.canPatch(diff)) {
+      if (client.saveDiffs) {
+        diffs.save(loaded, deployment, diff)
       }
-    )
-
-  return new Promise((resolve, reject) => {
-    single(client, namespace, name).get()
-      .then(
-        loaded => {
-          const diff = diffs.simple(loaded, deployment)
-          if (_.isEmpty(diff)) {
-            resolve()
-          } else {
-            if (diffs.canPatch(diff)) {
-              if (client.saveDiffs) {
-                diffs.save(loaded, deployment, diff)
-              }
-              updateDeployment(client, namespace, name, diff)
-                .then(
-                  resolve,
-                  reject
-                )
-            } else if (diffs.canReplace(diff)) {
-              replaceDeployment(client, namespace, name, deployment)
-                .then(
-                  resolve,
-                  reject
-                )
-            } else {
-              deletes[kind](client, namespace, name)
-            }
-          }
-        },
-        create.bind(null, resolve, reject)
-      )
-  })
+      await updateDeployment(client, namespace, name, diff)
+    } else if (diffs.canReplace(diff)) {
+      await replaceDeployment(client, namespace, name, deployment)
+    } else {
+      await deletes[kind](client, namespace, name)
+    }
+  }
 }
 
-function deleteDeployment (client, namespace, name) {
-  return new Promise((resolve, reject) => {
-    single(client, namespace, name).get()
-      .then(
-        () => {
-          single(client, namespace, name).delete()
-            .then(
-              result => {
-                checkDeployment(client, namespace, name, 'deletion', resolve)
-              },
-              err => {
-                reject(new Error(`Deployment '${namespace}.${name}' could not be deleted:\n\t${err.message}`))
-              }
-            )
-        },
-        () => resolve()
-      )
-  })
+async function deleteDeployment (client, namespace, name) {
+  try {
+    await single(client, namespace, name).get()
+  } catch (e) {
+    return
+  }
+  single(client, namespace, name).delete()
+    .catch(err => {
+      throw new Error(`Deployment '${namespace}.${name}' could not be deleted:\n\t${err.message}`)
+    })
+  await checkDeployment(client, namespace, name, 'deletion')
 }
 
-function getDeploymentsByNamespace (client, namespace, baseImage) {
-  return listDeployments(client, namespace)
-      .then(
-        list => {
-          let deployments = _.reduce(list.items, (acc, spec) => {
-            const containers = core.getContainersFromSpec(spec, baseImage)
-            containers.forEach(container => {
-              const metadata = parse(container.image)
-              acc.push({
-                namespace: namespace,
-                type: 'Deployments',
-                service: spec.metadata.name,
-                image: container.image,
-                container: container.name,
-                metadata: metadata,
-                labels: spec.spec.template.metadata
-                  ? spec.spec.template.metadata.labels
-                  : metadata.labels || {}
-              })
-            })
-            return acc
-          }, [])
-          return { namespace, deployments }
-        }
-      )
+async function getDeploymentsByNamespace (client, namespace, baseImage) {
+  const list = await listDeployments(client, namespace)
+  let deployments = _.reduce(list.items, (acc, spec) => {
+    const containers = core.getContainersFromSpec(spec, baseImage)
+    containers.forEach(container => {
+      const metadata = parse(container.image)
+      acc.push({
+        namespace: namespace,
+        type: 'Deployments',
+        service: spec.metadata.name,
+        image: container.image,
+        container: container.name,
+        metadata: metadata,
+        labels: spec.spec.template.metadata
+          ? spec.spec.template.metadata.labels
+          : metadata.labels || {}
+      })
+    })
+    return acc
+  }, [])
+
+  return { namespace, deployments }
 }
 
-function listDeployments (client, namespace) {
+async function listDeployments (client, namespace) {
   return multiple(client, namespace).list()
 }
 
-function replaceDeployment (client, namespace, name, spec) {
-  return new Promise((resolve, reject) => {
-    single(client, namespace, name).update(spec)
-      .then(
-        result => {
-          checkDeployment(client, namespace, name, 'updated', resolve)
-        },
-        err => {
-          reject(new Error(`Deployment '${namespace}.${name}' failed to replace:\n\t${err.message}`))
-        }
-      )
-  })
+async function replaceDeployment (client, namespace, name, spec) {
+  await single(client, namespace, name).update(spec)
+    .catch(err => {
+      throw new Error(`Deployment '${namespace}.${name}' failed to replace:\n\t${err.message}`)
+    })
+
+  await checkDeployment(client, namespace, name, 'updated')
 }
 
-function updateDeployment (client, namespace, name, diff) {
-  return new Promise((resolve, reject) => {
-    single(client, namespace, name).patch(diff)
-      .then(
-        result => {
-          checkDeployment(client, namespace, name, 'updated', resolve)
-        },
-        err => {
-          reject(new Error(`Deployment '${namespace}.${name}' failed to update:\n\t${err.message}`))
-        }
-      )
-  })
+async function updateDeployment (client, namespace, name, diff) {
+  await single(client, namespace, name).patch(diff)
+    .catch(err => {
+      throw new Error(`Deployment '${namespace}.${name}' failed to update:\n\t${err.message}`)
+    })
+
+  await checkDeployment(client, namespace, name, 'updated')
 }
 
-function upgradeDeployment (client, namespace, name, image, container) {
+async function upgradeDeployment (client, namespace, name, image, container) {
   const patch = diffs.getImagePatch(container || name, image)
-  return new Promise((resolve, reject) => {
-    single(client, namespace, name).patch(patch)
-      .then(
-        result => {
-          checkDeployment(client, namespace, name, 'updated', resolve)
-        },
-        err => {
-          reject(new Error(`Deployment '${namespace}.${name}' failed to upgrade:\n\t${err.message}`))
-        }
-      )
-  })
+  await single(client, namespace, name).patch(patch)
+    .catch(err => {
+      throw new Error(`Deployment '${namespace}.${name}' failed to upgrade:\n\t${err.message}`)
+    })
+
+  await checkDeployment(client, namespace, name, 'updated')
 }
 
 module.exports = function (client, deletes) {

--- a/src/k8s/deployment.js
+++ b/src/k8s/deployment.js
@@ -42,7 +42,7 @@ async function checkDeployment (client, namespace, name, outcome) {
         return
       } else {
         log.debug(`deployment '${namespace}.${name}' status check got API error. Checking again...`)
-        throw new Error('continue')
+        throw new Error('deployment not ready yet')
       }
     }
     log.debug(`deployment '${namespace}.${name}' status - '${JSON.stringify(result.status, null, 2)}'`)
@@ -52,9 +52,8 @@ async function checkDeployment (client, namespace, name, outcome) {
       return result
     } else if (outcome === 'deletion' && result.status.phase !== 'Terminating') {
       return result
-    } else {
-      throw new Error('continue')
     }
+    throw new Error('deployment not ready yet')
   })
 }
 

--- a/src/k8s/deployment.js
+++ b/src/k8s/deployment.js
@@ -96,7 +96,7 @@ async function deleteDeployment (client, namespace, name) {
   } catch (e) {
     return
   }
-  single(client, namespace, name).delete()
+  await single(client, namespace, name).delete()
     .catch(err => {
       throw new Error(`Deployment '${namespace}.${name}' could not be deleted:\n\t${err.message}`)
     })

--- a/src/k8s/job.js
+++ b/src/k8s/job.js
@@ -1,6 +1,5 @@
 const _ = require('lodash')
 const log = require('bole')('k8s')
-const Promise = require('bluebird')
 const diffs = require('./specDiff')
 const retry = require('../retry')
 

--- a/src/k8s/job.js
+++ b/src/k8s/job.js
@@ -2,6 +2,7 @@ const _ = require('lodash')
 const log = require('bole')('k8s')
 const Promise = require('bluebird')
 const diffs = require('./specDiff')
+const retry = require('../retry')
 
 function base (client, namespace) {
   return client
@@ -17,174 +18,116 @@ function multiple (client, namespace, name) {
   return base(client, namespace).jobs
 }
 
-function checkJob (client, namespace, name, outcome, resolve, reject, wait) {
-  let ms = wait || 500
-  let next = ms + (ms / 2)
-  if (next > 5000) {
-    next = 5000
-  }
-  setTimeout(() => {
+async function checkJob (client, namespace, name, outcome) {
+  await retry(async bail => {
     log.debug(`checking job status '${namespace}.${name}' for '${outcome}'`)
-    single(client, namespace, name).get()
-      .then(
-        result => {
-          try {
-            log.debug(`job '${namespace}.${name}' status - '${JSON.stringify(result.status, null, 2)}'`)
-            const status = result.status.conditions && result.status.conditions.length
-                              ? result.status.conditions[0] : {}
-            if (outcome === 'completion') {
-              if (status.type === 'Complete' && status.status === 'True') {
-                resolve(result)
-              } else if (status.type === 'Failed' && status.status === 'True') {
-                reject(new Error(`Job '${namespace}.${name}' failed to complete with status: '${JSON.stringify(result.status, null, 2)}'`))
-              } else {
-                checkJob(client, namespace, name, outcome, resolve, reject, next)
-              }
-            } else if (outcome === 'updated') {
-              if (status.type === 'Complete' && status.status === 'True') {
-                resolve(result)
-              } else if (status.type === 'Failed' && status.status === 'True') {
-                reject(new Error(`Job '${namespace}.${name}' failed to update with status: '${JSON.stringify(result.status, null, 2)}'`))
-              } else {
-                checkJob(client, namespace, name, outcome, resolve, reject, next)
-              }
-            } else {
-              checkJob(client, namespace, name, outcome, resolve, reject, next)
-            }
-          } catch (e) {
-            log.error(`error checking result '${JSON.stringify(result, null, 2)}':\n\t${e}`)
-          }
-        },
-        () => {
-          if (outcome === 'deletion') {
-            log.debug(`job '${namespace}.${name}' deleted successfully.`)
-            resolve()
-          } else {
-            log.debug(`job '${namespace}.${name}' status check got API error. Checking again in ${next} ms.`)
-            checkJob(client, namespace, name, outcome, resolve, reject, next)
-          }
+    try {
+      var result = await single(client, namespace, name).get()
+    } catch (err) {
+      if (outcome === 'deletion') {
+        log.debug(`job '${namespace}.${name}' deleted successfully.`)
+        return
+      } else {
+        log.debug(`job '${namespace}.${name}' status check got API error. Checking again soon.`)
+        throw new Error('continue')
+      }
+    }
+
+    try {
+      log.debug(`job '${namespace}.${name}' status - '${JSON.stringify(result.status, null, 2)}'`)
+      const status = result.status.conditions && result.status.conditions.length
+                        ? result.status.conditions[0] : {}
+      if (outcome === 'completion') {
+        if (status.type === 'Complete' && status.status === 'True') {
+          return result
+        } else if (status.type === 'Failed' && status.status === 'True') {
+          bail(new Error(`Job '${namespace}.${name}' failed to complete with status: '${JSON.stringify(result.status, null, 2)}'`))
         }
-      )
-  }, ms)
+      } else if (outcome === 'updated') {
+        if (status.type === 'Complete' && status.status === 'True') {
+          return result
+        } else if (status.type === 'Failed' && status.status === 'True') {
+          bail(new Error(`Job '${namespace}.${name}' failed to update with status: '${JSON.stringify(result.status, null, 2)}'`))
+        }
+      }
+    } catch (e) {
+      log.error(`error checking result '${JSON.stringify(result, null, 2)}':\n\t${e}`)
+    }
+    throw new Error('continue')
+  })
 }
 
-function createJob (client, deletes, jobSpec) {
+async function createJob (client, deletes, jobSpec) {
   const namespace = jobSpec.metadata.namespace || 'default'
   const name = jobSpec.metadata.name
-  let create = (resolve, reject) =>
-    multiple(client, namespace).create(jobSpec)
-    .then(
-      result => {
-        checkJob(client, namespace, name, 'completion', resolve, reject)
-      },
-      err => {
-        reject(new Error(` Job '${namespace}.${name}' failed to create:\n\t${err.message}`))
+  let create = async () => {
+    await multiple(client, namespace).create(jobSpec)
+      .catch(err => {
+        throw new Error(` Job '${namespace}.${name}' failed to create:\n\t${err.message}`)
+      })
+    await checkJob(client, namespace, name, 'completion')
+  }
+  try {
+    var loaded = await single(client, namespace, name).get()
+  } catch (err) {
+    await create()
+  }
+  const diff = diffs.simple(loaded, jobSpec)
+  if (!_.isEmpty(diff)) {
+    if (diffs.canPatch(diff, 'job') || diffs.isBackoffOnly(diff, jobSpec)) {
+      if (client.saveDiffs) {
+        diffs.save(loaded, jobSpec, diff)
       }
-    )
-  return new Promise((resolve, reject) => {
-    single(client, namespace, name).get()
-      .then(
-        loaded => {
-          const diff = diffs.simple(loaded, jobSpec)
-          if (_.isEmpty(diff)) {
-            resolve()
-          } else {
-            if (diffs.canPatch(diff, 'job') || diffs.isBackoffOnly(diff, jobSpec)) {
-              if (client.saveDiffs) {
-                diffs.save(loaded, jobSpec, diff)
-              }
-              updateJob(client, namespace, name, diff)
-                .then(
-                  resolve,
-                  reject
-                )
-            } else if (diffs.canReplace(diff, 'job')) {
-              replaceJob(client, namespace, name, jobSpec)
-                .then(
-                  resolve,
-                  reject
-                )
-            } else {
-              deleteJob(client, namespace, name)
-                .then(
-                  create.bind(null, resolve, reject),
-                  reject
-                )
-            }
-          }
-        },
-        create.bind(null, resolve, reject)
-      )
-  })
+      await updateJob(client, namespace, name, diff)
+    } else if (diffs.canReplace(diff, 'job')) {
+      await replaceJob(client, namespace, name, jobSpec)
+    } else {
+      await deleteJob(client, namespace, name)
+      await create()
+    }
+  }
 }
 
-function deleteJob (client, namespace, name) {
-  return new Promise((resolve, reject) => {
-    single(client, namespace, name).get()
-      .then(
-        () => {
-          single(client, namespace, name).delete()
-            .then(
-              result => {
-                checkJob(client, namespace, name, 'deletion', resolve)
-              },
-              err => {
-                reject(new Error(`Job '${namespace}.${name}' could not be deleted:\n\t${err.message}`))
-              }
-            )
-        },
-        () => { resolve() }
-      )
-  })
+async function deleteJob (client, namespace, name) {
+  try {
+    await single(client, namespace, name).get()
+    await single(client, namespace, name).delete()
+      .catch(err => {
+        throw new Error(`Job '${namespace}.${name}' could not be deleted:\n\t${err.message}`)
+      })
+    await checkJob(client, namespace, name, 'deletion')
+  } catch (err) {}
 }
 
 function listJobs (client, namespace) {
   return multiple(client, namespace).list()
 }
 
-function replaceJob (client, namespace, name, spec) {
-  return new Promise((resolve, reject) => {
-    single(client, namespace, name).update(spec)
-      .then(
-        result => {
-          checkJob(client, namespace, name, 'updated', resolve)
-        },
-        err => {
-          reject(new Error(`Job '${namespace}.${name}' failed to replace:\n\t${err.message}`))
-        }
-      )
-  })
+async function replaceJob (client, namespace, name, spec) {
+  await single(client, namespace, name).update(spec)
+    .catch(err => {
+      throw new Error(`Job '${namespace}.${name}' failed to replace:\n\t${err.message}`)
+    })
+  await checkJob(client, namespace, name, 'updated')
 }
 
-function runJob (client, deletes, namespace, name, spec) {
-  const steps = [
-    () => deleteJob(client, namespace, name),
-    () => createJob(client, deletes, spec)
-  ]
-  return Promise.mapSeries(steps, s => s())
-    .then(
-      () => {
-        log.info(`job '${name}' in namespace '${namespace}' completed successfully`)
-      },
-      err => {
-        log.error(`running job '${name}' in namespace '${namespace}' failed with: ${err.stack}`)
-        throw new Error(`running job '${name}' in namespace '${namespace}' failed`)
-      }
-    )
+async function runJob (client, deletes, namespace, name, spec) {
+  try {
+    await deleteJob(client, namespace, name)
+    await createJob(client, deletes, spec)
+  } catch (err) {
+    log.error(`running job '${name}' in namespace '${namespace}' failed with: ${err.stack}`)
+    throw new Error(`running job '${name}' in namespace '${namespace}' failed`)
+  }
+  log.info(`job '${name}' in namespace '${namespace}' completed successfully`)
 }
 
-function updateJob (client, namespace, name, diff) {
-  return new Promise((resolve, reject) => {
-    single(client, namespace, name).patch(diff)
-      .then(
-        result => {
-          checkJob(client, namespace, name, 'updated', resolve)
-        },
-        err => {
-          reject(new Error(`Job '${namespace}.${name}' failed to update:\n\t${err.message}`))
-        }
-      )
-  })
+async function updateJob (client, namespace, name, diff) {
+  await single(client, namespace, name).patch(diff)
+    .catch(err => {
+      throw new Error(`Job '${namespace}.${name}' failed to update:\n\t${err.message}`)
+    })
+  await checkJob(client, namespace, name, 'updated')
 }
 
 module.exports = function (client, deletes) {

--- a/src/k8s/job.js
+++ b/src/k8s/job.js
@@ -28,7 +28,7 @@ async function checkJob (client, namespace, name, outcome) {
         return
       } else {
         log.debug(`job '${namespace}.${name}' status check got API error. Checking again soon.`)
-        throw new Error('continue')
+        throw new Error('job not ready yet')
       }
     }
 
@@ -52,7 +52,7 @@ async function checkJob (client, namespace, name, outcome) {
     } catch (e) {
       log.error(`error checking result '${JSON.stringify(result, null, 2)}':\n\t${e}`)
     }
-    throw new Error('continue')
+    throw new Error('job not ready yet')
   })
 }
 
@@ -69,7 +69,7 @@ async function createJob (client, deletes, jobSpec) {
   try {
     var loaded = await single(client, namespace, name).get()
   } catch (err) {
-    await create()
+    return create()
   }
   const diff = diffs.simple(loaded, jobSpec)
   if (!_.isEmpty(diff)) {

--- a/src/k8s/manifest.js
+++ b/src/k8s/manifest.js
@@ -40,7 +40,7 @@ function checkManifest (client, manifest, outcome, resolve, limit, wait) {
         log.debug(`service '${namespace}.${name}' deleted successfully.`)
         return
       } else {
-        log.debug(`checking service '${namespace}.${name}' status - resulted in API error. Checking again in ${next} ms.`)
+        log.debug(`checking service '${namespace}.${name}' status - resulted in API error. Checking again soon.`)
         throw new Error('continue')
       }
     }

--- a/src/k8s/manifest.js
+++ b/src/k8s/manifest.js
@@ -27,7 +27,7 @@ function multiple (client, manifest) {
   return base(client, manifest)[plural]
 }
 
-async function checkManifest (client, manifest, outcome, resolve, limit, wait) {
+async function checkManifest (client, manifest, outcome) {
   const namespace = manifest.metadata.namespace || 'default'
   const name = manifest.metadata.name
 
@@ -48,8 +48,6 @@ async function checkManifest (client, manifest, outcome, resolve, limit, wait) {
     if (outcome === 'creation' && result.status) {
       return result
     } else if (outcome === 'update' && result.status) {
-      return result
-    } else if (limit <= 0) {
       return result
     }
     throw new Error('manifest not ready yet')

--- a/src/k8s/manifest.js
+++ b/src/k8s/manifest.js
@@ -27,12 +27,12 @@ function multiple (client, manifest) {
   return base(client, manifest)[plural]
 }
 
-function checkManifest (client, manifest, outcome, resolve, limit, wait) {
+async function checkManifest (client, manifest, outcome, resolve, limit, wait) {
   const namespace = manifest.metadata.namespace || 'default'
   const name = manifest.metadata.name
-  log.debug(`checking service status '${namespace}.${name}' for '${outcome}'`)
 
   return retry(async () => {
+    log.debug(`checking service status '${namespace}.${name}' for '${outcome}'`)
     try {
       var result = await single(client, manifest).get()
     } catch (err) {

--- a/src/k8s/manifest.js
+++ b/src/k8s/manifest.js
@@ -41,7 +41,7 @@ async function checkManifest (client, manifest, outcome, resolve, limit, wait) {
         return
       } else {
         log.debug(`checking service '${namespace}.${name}' status - resulted in API error. Checking again soon.`)
-        throw new Error('continue')
+        throw new Error('manifest not ready yet')
       }
     }
     log.debug(`service '${namespace}.${name}' status - '${JSON.stringify(result, null, 2)}'`)
@@ -52,7 +52,7 @@ async function checkManifest (client, manifest, outcome, resolve, limit, wait) {
     } else if (limit <= 0) {
       return result
     }
-    throw new Error('continue')
+    throw new Error('manifest not ready yet')
   })
 }
 

--- a/src/k8s/manifest.js
+++ b/src/k8s/manifest.js
@@ -1,8 +1,8 @@
 const _ = require('lodash')
 const log = require('bole')('k8s')
-const Promise = require('bluebird')
 const diffs = require('./specDiff')
 const pluralize = require('pluralize')
+const retry = require('../retry')
 
 function base (client, manifest) {
   const namespace = manifest.metadata.namespace || 'default'
@@ -28,115 +28,80 @@ function multiple (client, manifest) {
 }
 
 function checkManifest (client, manifest, outcome, resolve, limit, wait) {
-  let ms = wait || 500
-  let next = ms + (ms / 2)
-  if (limit === undefined) {
-    limit = 10000
-  } else {
-
-  }
   const namespace = manifest.metadata.namespace || 'default'
   const name = manifest.metadata.name
   log.debug(`checking service status '${namespace}.${name}' for '${outcome}'`)
 
-  setTimeout(() => {
-    single(client, manifest).get()
-      .then(
-        result => {
-          log.debug(`service '${namespace}.${name}' status - '${JSON.stringify(result, null, 2)}'`)
-          if (outcome === 'creation' && result.status) {
-            resolve(result)
-          } else if (outcome === 'update' && result.status) {
-            resolve(result)
-          } else if (limit <= 0) {
-            resolve(result)
-          } else {
-            checkManifest(client, manifest, outcome, resolve, limit - ms, next)
-          }
-        },
-        () => {
-          if (outcome === 'deletion') {
-            log.debug(`service '${namespace}.${name}' deleted successfully.`)
-            resolve()
-          } else {
-            log.debug(`checking service '${namespace}.${name}' status - resulted in API error. Checking again in ${next} ms.`)
-            checkManifest(client, manifest, outcome, resolve, limit - ms, next)
-          }
-        }
-      )
-  }, ms)
-}
-
-function createManifest (client, manifest) {
-  const namespace = manifest.metadata.namespace || 'default'
-  const name = manifest.metadata.name
-  let create = (resolve, reject) =>
-    multiple(client, manifest).create(manifest)
-    .then(
-      result => {
-        checkManifest(client, manifest, 'creation', resolve)
-      },
-      err => {
-        reject(new Error(`Manifest '${namespace}.${name}' failed to create:\n\t${err.message}`))
+  return retry(async () => {
+    try {
+      var result = await single(client, manifest).get()
+    } catch (err) {
+      if (outcome === 'deletion') {
+        log.debug(`service '${namespace}.${name}' deleted successfully.`)
+        return
+      } else {
+        log.debug(`checking service '${namespace}.${name}' status - resulted in API error. Checking again in ${next} ms.`)
+        throw new Error('continue')
       }
-    )
-  return new Promise((resolve, reject) => {
-    single(client, manifest).get()
-      .then(
-        loaded => {
-          const diff = diffs.simple(loaded, manifest)
-          if (_.isEmpty(diff)) {
-            resolve()
-          } else {
-            if (diffs.canPatch(diff)) {
-              if (client.saveDiffs) {
-                diffs.save(loaded, manifest, diff)
-              }
-              updateManifest(client, manifest, diff)
-                .then(
-                  resolve,
-                  reject
-                )
-            } else if (diffs.canReplace(diff)) {
-              replaceManifest(client, manifest)
-                .then(
-                  resolve,
-                  reject
-                )
-            } else {
-              deleteManifest(client, manifest)
-                .then(
-                  create.bind(null, resolve, reject),
-                  reject
-                )
-            }
-          }
-        },
-        create.bind(null, resolve, reject)
-      )
+    }
+    log.debug(`service '${namespace}.${name}' status - '${JSON.stringify(result, null, 2)}'`)
+    if (outcome === 'creation' && result.status) {
+      return result
+    } else if (outcome === 'update' && result.status) {
+      return result
+    } else if (limit <= 0) {
+      return result
+    }
+    throw new Error('continue')
   })
 }
 
-function deleteManifest (client, manifest) {
+async function createManifest (client, manifest) {
   const namespace = manifest.metadata.namespace || 'default'
   const name = manifest.metadata.name
-  return new Promise((resolve, reject) => {
-    single(client, manifest).get()
-      .then(
-        () => {
-          single(client, manifest).delete()
-            .then(
-              result => {
-                checkManifest(client, manifest, 'deletion', resolve)
-              },
-              err => {
-                reject(new Error(`Manifest '${namespace}.${name}' could not be deleted:\n\t${err.message}`))
-              }
-            )
-        },
-        () => { resolve() }
-      )
-  })
+  let create = async () => {
+    await multiple(client, manifest).create(manifest)
+      .catch(err => {
+        throw new Error(`Manifest '${namespace}.${name}' failed to create:\n\t${err.message}`)
+      })
+    await checkManifest(client, manifest, 'creation')
+  }
+
+  try {
+    var loaded = await single(client, manifest).get()
+  } catch (err) {
+    await create()
+    return
+  }
+  const diff = diffs.simple(loaded, manifest)
+  if (!_.isEmpty(diff)) {
+    if (diffs.canPatch(diff)) {
+      if (client.saveDiffs) {
+        diffs.save(loaded, manifest, diff)
+      }
+      await updateManifest(client, manifest, diff)
+    } else if (diffs.canReplace(diff)) {
+      await replaceManifest(client, manifest)
+    } else {
+      await deleteManifest(client, manifest)
+    }
+  }
+}
+
+async function deleteManifest (client, manifest) {
+  const namespace = manifest.metadata.namespace || 'default'
+  const name = manifest.metadata.name
+  try {
+    await single(client, manifest).get()
+  } catch (err) {
+    return
+  }
+
+  await single(client, manifest).delete()
+    .catch(err => {
+      throw new Error(`Manifest '${namespace}.${name}' could not be deleted:\n\t${err.message}`)
+    })
+  await checkManifest(client, manifest, 'deletion')
 }
 
 function listManifests (client, apiVersion, kind) {
@@ -146,36 +111,24 @@ function listManifests (client, apiVersion, kind) {
   return multiple(client, manifest).list()
 }
 
-function replaceManifest (client, manifest) {
+async function replaceManifest (client, manifest) {
   const namespace = manifest.metadata.namespace || 'default'
   const name = manifest.metadata.name
-  return new Promise((resolve, reject) => {
-    single(client, manifest).update(manifest)
-      .then(
-        result => {
-          checkManifest(client, manifest, 'update', resolve)
-        },
-        err => {
-          reject(new Error(`Manifest '${namespace}.${name}' failed to replace:\n\t${err.message}`))
-        }
-      )
-  })
+  await single(client, manifest).update(manifest)
+    .catch(err => {
+      throw new Error(`Manifest '${namespace}.${name}' failed to replace:\n\t${err.message}`)
+    })
+  await checkManifest(client, manifest, 'update')
 }
 
-function updateManifest (client, manifest, diff) {
+async function updateManifest (client, manifest, diff) {
   const namespace = manifest.metadata.namespace || 'default'
   const name = manifest.metadata.name
-  return new Promise((resolve, reject) => {
-    single(client, manifest).patch(diff)
-      .then(
-        result => {
-          checkManifest(client, manifest, 'update', resolve)
-        },
-        err => {
-          reject(new Error(`Manifest '${namespace}.${name}' failed to update:\n\t${err.message}`))
-        }
-      )
-  })
+  await single(client, manifest).patch(diff)
+    .catch(err => {
+      throw new Error(`Manifest '${namespace}.${name}' failed to update:\n\t${err.message}`)
+    })
+  await checkManifest(client, manifest, 'update')
 }
 
 module.exports = function (client) {

--- a/src/k8s/namespace.js
+++ b/src/k8s/namespace.js
@@ -15,7 +15,7 @@ async function checkNamespace (client, namespace, outcome, resolve, wait) {
         return
       } else {
         log.debug(`namespace '${namespace}' status - resulted in API error. Checking again in ${next} ms.`)
-        throw new Error('continue')
+        throw new Error('namespace not ready yet')
       }
     }
 
@@ -25,7 +25,7 @@ async function checkNamespace (client, namespace, outcome, resolve, wait) {
     } else if (outcome === 'deletion' && result.status.phase !== 'Terminating') {
       return result
     }
-    throw new Error('continue')
+    throw new Error('namespace not ready yet')
   })
 }
 
@@ -44,7 +44,6 @@ async function createNamespace (client, namespace) {
   try {
     var result = await getNamespace(client, namespace)
   } catch (err) {
-    log.error(err.stack)
     result = await client.namespaces.create(namespaceSpec)
       .catch(err => {
         throw new Error(`Namespace '${namespace}' failed to create:\n\t${err.message}`)

--- a/src/k8s/namespace.js
+++ b/src/k8s/namespace.js
@@ -44,6 +44,7 @@ async function createNamespace (client, namespace) {
   try {
     var result = await getNamespace(client, namespace)
   } catch (err) {
+    log.error(err.stack)
     result = await client.namespaces.create(namespaceSpec)
       .catch(err => {
         throw new Error(`Namespace '${namespace}' failed to create:\n\t${err.message}`)

--- a/src/k8s/namespace.js
+++ b/src/k8s/namespace.js
@@ -2,9 +2,7 @@ const log = require('bole')('k8s')
 const Promise = require('bluebird')
 const retry = require('../retry')
 
-async function checkNamespace (client, namespace, outcome, resolve, wait) {
-  let ms = wait || 250
-  let next = ms + (ms / 2)
+async function checkNamespace (client, namespace, outcome) {
   log.debug(`checking namespace status '${namespace}' for '${outcome}'`)
   return retry(async () => {
     try {
@@ -14,7 +12,7 @@ async function checkNamespace (client, namespace, outcome, resolve, wait) {
         log.debug(`namespace '${namespace}' deleted successfully`)
         return
       } else {
-        log.debug(`namespace '${namespace}' status - resulted in API error. Checking again in ${next} ms.`)
+        log.debug(`namespace '${namespace}' status - resulted in API error. Checking again soon.`)
         throw new Error('namespace not ready yet')
       }
     }

--- a/src/k8s/networkPolicy.js
+++ b/src/k8s/networkPolicy.js
@@ -42,8 +42,7 @@ async function createNetworkPolicy (client, deletes, networkPolicy) {
   try {
     var loaded = await single(client, namespace, name).get()
   } catch (err) {
-    await create()
-    return
+    return create()
   }
   const diff = diffs.simple(loaded, networkPolicy)
   if (!_.isEmpty(diff)) {

--- a/src/k8s/networkPolicy.js
+++ b/src/k8s/networkPolicy.js
@@ -1,5 +1,4 @@
 const _ = require('lodash')
-const Promise = require('bluebird')
 const core = require('./core')
 const diffs = require('./specDiff')
 
@@ -29,141 +28,97 @@ function multiple (client, namespace, name) {
   return base(client, namespace).networkpolicies
 }
 
-function createNetworkPolicy (client, deletes, networkPolicy) {
+async function createNetworkPolicy (client, deletes, networkPolicy) {
   const namespace = networkPolicy.metadata.namespace || 'default'
   const name = networkPolicy.metadata.name
 
-  let create = (resolve, reject) =>
-    multiple(client, namespace).create(networkPolicy)
-    .then(
-      () => resolve(),
-      err => {
-        reject(new Error(`NetworkPolicy '${namespace}.${name}' failed to create:\n\t${err.message}`))
+  let create = async () => {
+    await multiple(client, namespace).create(networkPolicy)
+      .catch(err => {
+        throw new Error(`NetworkPolicy '${namespace}.${name}' failed to create:\n\t${err.message}`)
+      })
+  }
+
+  try {
+    var loaded = await single(client, namespace, name).get()
+  } catch (err) {
+    await create()
+    return
+  }
+  const diff = diffs.simple(loaded, networkPolicy)
+  if (!_.isEmpty(diff)) {
+    if (diffs.canPatch(diff)) {
+      if (client.saveDiffs) {
+        diffs.save(loaded, networkPolicy, diff)
       }
-    )
-
-  return new Promise((resolve, reject) => {
-    single(client, namespace, name).get()
-      .then(
-        loaded => {
-          const diff = diffs.simple(loaded, networkPolicy)
-          if (_.isEmpty(diff)) {
-            resolve()
-          } else {
-            if (diffs.canPatch(diff)) {
-              if (client.saveDiffs) {
-                diffs.save(loaded, networkPolicy, diff)
-              }
-              patchNetworkPolicy(client, namespace, name, diff)
-                .then(
-                  resolve,
-                  reject
-                )
-            } else if (diffs.canReplace(diff)) {
-              replaceNetworkPolicy(client, namespace, name, networkPolicy)
-                .then(
-                  resolve,
-                  reject
-                )
-            } else {
-              deleteNetworkPolicy(client, namespace, name)
-                .then(
-                  create.bind(null, resolve, reject),
-                  reject
-                )
-            }
-          }
-        },
-        create.bind(null, resolve, reject)
-      )
-  })
+      await patchNetworkPolicy(client, namespace, name, diff)
+    } else if (diffs.canReplace(diff)) {
+      await replaceNetworkPolicy(client, namespace, name, networkPolicy)
+    } else {
+      await deleteNetworkPolicy(client, namespace, name)
+      await create()
+    }
+  }
 }
 
-function deleteNetworkPolicy (client, namespace, name) {
-  return new Promise((resolve, reject) => {
-    single(client, namespace, name).get()
-      .then(
-        () => {
-          single(client, namespace, name).delete()
-            .then(
-              () => resolve(),
-              err => {
-                reject(new Error(`NetworkPolicy '${namespace}.${name}' could not be deleted:\n\t${err.message}`))
-              }
-            )
-        },
-        () => {
-          resolve()
-        }
-      )
-  })
+async function deleteNetworkPolicy (client, namespace, name) {
+  try {
+    await single(client, namespace, name).get()
+  } catch (err) {
+    return
+  }
+  await single(client, namespace, name).delete()
+    .catch(err => {
+      throw new Error(`NetworkPolicy '${namespace}.${name}' could not be deleted:\n\t${err.message}`)
+    })
 }
 
-function getNetworkPoliciesByNamespace (client, namespace, baseImage) {
-  return listNetworkPolicies(client, namespace)
-      .then(
-        list => {
-          let networkPolicies = _.reduce(list.items, (acc, spec) => {
-            const containers = core.getContainersFromSpec(spec, baseImage)
-            containers.forEach(container => {
-              acc.push({
-                namespace: namespace,
-                type: 'NetworkPolicy',
-                service: spec.metadata.name,
-                image: container.image,
-                container: container.name,
-                metadata: spec.metadata,
-                labels: spec.template.metadata
-                  ? spec.template.metadata.labels
-                  : {}
-              })
-            })
-            return acc
-          }, [])
-          return { namespace, networkPolicies }
-        }
-      )
+async function getNetworkPoliciesByNamespace (client, namespace, baseImage) {
+  const list = await listNetworkPolicies(client, namespace)
+  let networkPolicies = _.reduce(list.items, (acc, spec) => {
+    const containers = core.getContainersFromSpec(spec, baseImage)
+    containers.forEach(container => {
+      acc.push({
+        namespace: namespace,
+        type: 'NetworkPolicy',
+        service: spec.metadata.name,
+        image: container.image,
+        container: container.name,
+        metadata: spec.metadata,
+        labels: spec.template.metadata
+          ? spec.template.metadata.labels
+          : {}
+      })
+    })
+    return acc
+  }, [])
+  return { namespace, networkPolicies }
 }
 
-function listNetworkPolicies (client, namespace) {
+async function listNetworkPolicies (client, namespace) {
   return multiple(client, namespace).list()
 }
 
-function patchNetworkPolicy (client, namespace, name, diff) {
-  return new Promise((resolve, reject) => {
-    single(client, namespace, name).patch(diff)
-      .then(
-        () => resolve(),
-        err => {
-          reject(new Error(`NetworkPolicy '${namespace}.${name}' failed to patch:\n\t${err.message}`))
-        }
-      )
-  })
+async function patchNetworkPolicy (client, namespace, name, diff) {
+  await single(client, namespace, name).patch(diff)
+    .catch(err => {
+      throw new Error(`NetworkPolicy '${namespace}.${name}' failed to patch:\n\t${err.message}`)
+    })
 }
 
-function replaceNetworkPolicy (client, namespace, name, spec) {
-  return new Promise((resolve, reject) => {
-    single(client, namespace, name).update(spec)
-      .then(
-        () => resolve(),
-        err => {
-          reject(new Error(`NetworkPolicy '${namespace}.${name}' failed to replace:\n\t${err.message}`))
-        }
-      )
-  })
+async function replaceNetworkPolicy (client, namespace, name, spec) {
+  await single(client, namespace, name).update(spec)
+    .catch(err => {
+      throw new Error(`NetworkPolicy '${namespace}.${name}' failed to replace:\n\t${err.message}`)
+    })
 }
 
-function updateNetworkPolicy (client, namespace, name, image, container) {
+async function updateNetworkPolicy (client, namespace, name, image, container) {
   const patch = diffs.getImagePatch(container || name, image)
-  return new Promise((resolve, reject) => {
-    single(client, namespace, name).patch(patch)
-      .then(
-        () => resolve(),
-        err => {
-          reject(new Error(`NetworkPolicy '${namespace}.${name}' failed to upgrade:\n\t${err.message}`))
-        }
-      )
-  })
+  await single(client, namespace, name).patch(patch)
+    .catch(err => {
+      throw new Error(`NetworkPolicy '${namespace}.${name}' failed to upgrade:\n\t${err.message}`)
+    })
 }
 
 module.exports = function (client, deletes) {

--- a/src/k8s/role.js
+++ b/src/k8s/role.js
@@ -42,40 +42,32 @@ function multiple (client, namespace) {
   }
 }
 
-function createRole (client, role) {
+async function createRole (client, role) {
   const namespace = role.metadata.namespace || 'default'
   const name = role.metadata.name
   const appliedns = role.kind === 'ClusterRole'
     ? undefined : namespace
-  return single(client, name, appliedns).get()
-    .then(
-      () => Promise.resolve(),
-      () => {
-        return multiple(client, appliedns).create(role)
-          .then(
-            null,
-            err => {
-              throw new Error(`${role.kind} '${role.metadata.namespace}.${role.metadata.name}' failed to create:\n\t${err.message}`)
-            }
-          )
-      }
-    )
+
+  try {
+    await single(client, name, appliedns).get()
+  } catch (e) {
+    return multiple(client, appliedns).create(role)
+      .catch(err => {
+        throw new Error(`${role.kind} '${role.metadata.namespace}.${role.metadata.name}' failed to create:\n\t${err.message}`)
+      })
+  }
 }
 
-function deleteRole (client, namespace, name) {
-  return single(client, name, namespace).get()
-    .then(
-      (spec) => {
-        return single(client, name, namespace).delete()
-          .then(
-            null,
-            err => {
-              throw new Error(`${spec.kind} '${namespace}.${name}' could not be deleted:\n\t${err.message}`)
-            }
-          )
-      },
-      () => { return true }
-    )
+async function deleteRole (client, namespace, name) {
+  try {
+    var spec = await single(client, name, namespace).get()
+  } catch (err) {
+    return true
+  }
+  return single(client, name, namespace).delete()
+    .catch(err => {
+      throw new Error(`${spec.kind} '${namespace}.${name}' could not be deleted:\n\t${err.message}`)
+    })
 }
 
 function listRoles (client, namespace) {

--- a/src/k8s/roleBinding.js
+++ b/src/k8s/roleBinding.js
@@ -11,7 +11,7 @@ function group (client) {
   return GROUPS[client.version]
 }
 
-async function base (client, namespace) {
+function base (client, namespace) {
   if (namespace) {
     return client
       .group(group(client))
@@ -22,7 +22,7 @@ async function base (client, namespace) {
   }
 }
 
-async function single (client, name, namespace) {
+function single (client, name, namespace) {
   if (namespace) {
     return base(client, namespace)
       .rolebinding(name)
@@ -32,7 +32,7 @@ async function single (client, name, namespace) {
   }
 }
 
-async function multiple (client, namespace) {
+function multiple (client, namespace) {
   if (namespace) {
     return base(client, namespace)
       .rolebindings

--- a/src/k8s/service.js
+++ b/src/k8s/service.js
@@ -16,8 +16,8 @@ function multiple (client, namespace, name) {
   return base(client, namespace).services
 }
 
-function checkService (client, namespace, name, outcome) {
-  retry(async () => {
+async function checkService (client, namespace, name, outcome) {
+  await retry(async () => {
     log.debug(`checking service status '${namespace}.${name}' for '${outcome}'`)
     try {
       var result = await single(client, namespace, name).get()

--- a/src/k8s/service.js
+++ b/src/k8s/service.js
@@ -77,7 +77,7 @@ async function createService (client, deletes, service) {
 
 async function deleteService (client, namespace, name) {
   try {
-    single(client, namespace, name).get()
+    await single(client, namespace, name).get()
   } catch (e) {
     return
   }

--- a/src/k8s/service.js
+++ b/src/k8s/service.js
@@ -27,7 +27,7 @@ async function checkService (client, namespace, name, outcome) {
         return
       } else {
         log.debug(`checking service '${namespace}.${name}' status - resulted in API error. Checking again soon.`)
-        throw new Error('continue')
+        throw new Error('service not ready yet')
       }
     }
 
@@ -37,7 +37,7 @@ async function checkService (client, namespace, name, outcome) {
     } else if (outcome === 'update' && result.status.loadBalancer) {
       return result
     }
-    throw new Error('continue')
+    throw new Error('service not ready yet')
   })
 }
 
@@ -56,8 +56,7 @@ async function createService (client, deletes, service) {
   try {
     var loaded = await single(client, namespace, name).get()
   } catch (e) {
-    await create()
-    return
+    return create()
   }
   const diff = diffs.simple(loaded, service)
   if (!_.isEmpty(diff)) {

--- a/src/k8s/service.js
+++ b/src/k8s/service.js
@@ -2,6 +2,7 @@ const _ = require('lodash')
 const log = require('bole')('k8s')
 const Promise = require('bluebird')
 const diffs = require('./specDiff')
+const retry = require('../retry')
 
 function base (client, namespace) {
   return client
@@ -16,139 +17,98 @@ function multiple (client, namespace, name) {
   return base(client, namespace).services
 }
 
-function checkService (client, namespace, name, outcome, resolve, wait) {
-  let ms = wait || 500
-  let next = ms + (ms / 2)
-  if (next > 5000) {
-    next = 5000
-  }
-  log.debug(`checking service status '${namespace}.${name}' for '${outcome}'`)
-  setTimeout(() => {
-    single(client, namespace, name).get()
-      .then(
-        result => {
-          log.debug(`service '${namespace}.${name}' status - '${JSON.stringify(result.status, null, 2)}'`)
-          if (outcome === 'creation' && result.status.loadBalancer) {
-            resolve(result)
-          } else if (outcome === 'update' && result.status.loadBalancer) {
-            resolve(result)
-          } else {
-            checkService(client, namespace, name, outcome, resolve, next)
-          }
-        },
-        () => {
-          if (outcome === 'deletion') {
-            log.debug(`service '${namespace}.${name}' deleted successfully.`)
-            resolve()
-          } else {
-            log.debug(`checking service '${namespace}.${name}' status - resulted in API error. Checking again in ${next} ms.`)
-            checkService(client, namespace, name, outcome, resolve, next)
-          }
-        }
-      )
-  }, ms)
+function checkService (client, namespace, name, outcome) {
+  retry(async () => {
+    log.debug(`checking service status '${namespace}.${name}' for '${outcome}'`)
+    try {
+      var result = await single(client, namespace, name).get()
+    } catch (err) {
+      if (outcome === 'deletion') {
+        log.debug(`service '${namespace}.${name}' deleted successfully.`)
+        return
+      } else {
+        log.debug(`checking service '${namespace}.${name}' status - resulted in API error. Checking again in ${next} ms.`)
+        checkService(client, namespace, name, outcome, resolve, next)
+        throw new Error('continue')
+      }
+    }
+
+    log.debug(`service '${namespace}.${name}' status - '${JSON.stringify(result.status, null, 2)}'`)
+    if (outcome === 'creation' && result.status.loadBalancer) {
+      return result
+    } else if (outcome === 'update' && result.status.loadBalancer) {
+      return result
+    }
+    throw new Error('continue')
+  })
 }
 
-function createService (client, deletes, service) {
+async function createService (client, deletes, service) {
   const namespace = service.metadata.namespace || 'default'
   const name = service.metadata.name
-  let create = (resolve, reject) =>
-    multiple(client, namespace).create(service)
-    .then(
-      result => {
-        checkService(client, namespace, name, 'creation', resolve)
-      },
-      err => {
-        reject(new Error(`Service '${namespace}.${name}' failed to create:\n\t${err.message}`))
+  let create = async () => {
+    await multiple(client, namespace).create(service)
+      .catch(err => {
+        throw new Error(`Service '${namespace}.${name}' failed to create:\n\t${err.message}`)
+      })
+
+    await checkService(client, namespace, name, 'creation')
+  }
+
+  try {
+    var loaded = await single(client, namespace, name).get()
+  } catch (e) {
+    await create()
+    return
+  }
+  const diff = diffs.simple(loaded, service)
+  if (!_.isEmpty(diff)) {
+    if (diffs.canPatch(diff)) {
+      if (client.saveDiffs) {
+        diffs.save(loaded, service, diff)
       }
-    )
-  return new Promise((resolve, reject) => {
-    single(client, namespace, name).get()
-      .then(
-        loaded => {
-          const diff = diffs.simple(loaded, service)
-          if (_.isEmpty(diff)) {
-            resolve()
-          } else {
-            if (diffs.canPatch(diff)) {
-              if (client.saveDiffs) {
-                diffs.save(loaded, service, diff)
-              }
-              updateService(client, namespace, name, diff)
-                .then(
-                  resolve,
-                  reject
-                )
-            } else if (diffs.canReplace(diff)) {
-              replaceService(client, namespace, name, service)
-                .then(
-                  resolve,
-                  reject
-                )
-            } else {
-              deleteService(client, namespace, name)
-                .then(
-                  create.bind(null, resolve, reject),
-                  reject
-                )
-            }
-          }
-        },
-        create.bind(null, resolve, reject)
-      )
-  })
+      await updateService(client, namespace, name, diff)
+    } else if (diffs.canReplace(diff)) {
+      await replaceService(client, namespace, name, service)
+    } else {
+      await deleteService(client, namespace, name)
+      await create()
+    }
 }
 
-function deleteService (client, namespace, name) {
-  return new Promise((resolve, reject) => {
+async function deleteService (client, namespace, name) {
+  try {
     single(client, namespace, name).get()
-      .then(
-        () => {
-          single(client, namespace, name).delete()
-            .then(
-              result => {
-                checkService(client, namespace, name, 'deletion', resolve)
-              },
-              err => {
-                reject(new Error(`Service '${namespace}.${name}' could not be deleted:\n\t${err.message}`))
-              }
-            )
-        },
-        () => { resolve() }
-      )
-  })
+  } catch (e) {
+    return
+  }
+  await single(client, namespace, name).delete()
+    .catch(err => {
+      throw new Error(`Service '${namespace}.${name}' could not be deleted:\n\t${err.message}`)
+    })
+  await checkService(client, namespace, name, 'deletion')
 }
 
 function listServices (client, namespace) {
   return multiple(client, namespace).list()
 }
 
-function replaceService (client, namespace, name, spec) {
-  return new Promise((resolve, reject) => {
-    single(client, namespace, name).update(spec)
-      .then(
-        result => {
-          checkService(client, namespace, name, 'update', resolve)
-        },
-        err => {
-          reject(new Error(`Service '${namespace}.${name}' failed to replace:\n\t${err.message}`))
-        }
-      )
-  })
+async function replaceService (client, namespace, name, spec) {
+  await single(client, namespace, name).update(spec)
+    .catch(err => {
+      throw new Error(`Service '${namespace}.${name}' failed to replace:\n\t${err.message}`)
+    })
+
+  await checkService(client, namespace, name, 'update')
 }
 
-function updateService (client, namespace, name, diff) {
-  return new Promise((resolve, reject) => {
-    single(client, namespace, name).patch(diff)
-      .then(
-        result => {
-          checkService(client, namespace, name, 'update', resolve)
-        },
-        err => {
-          reject(new Error(`Service '${namespace}.${name}' failed to update:\n\t${err.message}`))
-        }
-      )
-  })
+async function updateService (client, namespace, name, diff) {
+  await single(client, namespace, name).patch(diff)
+    .catch(err => {
+      throw new Error(`Service '${namespace}.${name}' failed to update:\n\t${err.message}`)
+    })
+
+  await checkService(client, namespace, name, 'update')
 }
 
 module.exports = function (client, deletes) {

--- a/src/k8s/service.js
+++ b/src/k8s/service.js
@@ -1,6 +1,5 @@
 const _ = require('lodash')
 const log = require('bole')('k8s')
-const Promise = require('bluebird')
 const diffs = require('./specDiff')
 const retry = require('../retry')
 
@@ -27,8 +26,7 @@ function checkService (client, namespace, name, outcome) {
         log.debug(`service '${namespace}.${name}' deleted successfully.`)
         return
       } else {
-        log.debug(`checking service '${namespace}.${name}' status - resulted in API error. Checking again in ${next} ms.`)
-        checkService(client, namespace, name, outcome, resolve, next)
+        log.debug(`checking service '${namespace}.${name}' status - resulted in API error. Checking again soon.`)
         throw new Error('continue')
       }
     }
@@ -74,6 +72,7 @@ async function createService (client, deletes, service) {
       await deleteService(client, namespace, name)
       await create()
     }
+  }
 }
 
 async function deleteService (client, namespace, name) {

--- a/src/k8s/statefulSet.js
+++ b/src/k8s/statefulSet.js
@@ -4,6 +4,7 @@ const Promise = require('bluebird')
 const core = require('./core')
 const diffs = require('./specDiff')
 const parse = require('../imageParser').parse
+const retry = require('../retry')
 
 const GROUPS = {
   '1.4': 'apps/v1beta1',
@@ -31,183 +32,131 @@ function multiple (client, namespace, name) {
   return base(client, namespace).statefulsets
 }
 
-function checkStatefulSet (client, namespace, name, outcome, resolve, wait) {
-  let ms = wait || 500
-  let next = ms + (ms / 2)
-  if (next > 5000) {
-    next = 5000
-  }
-  log.debug(`checking statefulSet status '${namespace}.${name}' for '${outcome}'`)
-  setTimeout(() => {
-    single(client, namespace, name).get()
-      .then(
-        result => {
-          log.debug(`statefulSet '${namespace}.${name}' status - '${JSON.stringify(result.status, null, 2)}'`)
-          if (outcome === 'creation' && result.status.readyReplicas > 0) {
-            resolve(result)
-          } else if (outcome === 'updated' && result.status.readyReplicas > 0) {
-            resolve(result)
-          } else if (outcome === 'deletion' && result.status.phase !== 'Terminating') {
-            resolve(result)
-          } else {
-            checkStatefulSet(client, namespace, name, outcome, resolve, next)
-          }
-        },
-        () => {
-          if (outcome === 'deletion') {
-            log.debug(`statefulSet '${namespace}.${name}' deleted successfully.`)
-            resolve()
-          } else {
-            log.debug(`statefulSet '${namespace}.${name}' status check got API error. Checking again in ${next} ms.`)
-            checkStatefulSet(client, namespace, name, outcome, resolve, next)
-          }
-        }
-      )
-  }, ms)
+async function checkStatefulSet (client, namespace, name, outcome) {
+  return retry(async () => {
+    log.debug(`checking statefulSet status '${namespace}.${name}' for '${outcome}'`)
+    try {
+      var result = await single(client, namespace, name).get()
+    } catch (err) {
+      if (outcome === 'deletion') {
+        log.debug(`statefulSet '${namespace}.${name}' deleted successfully.`)
+        return
+      } else {
+        log.debug(`statefulSet '${namespace}.${name}' status check got API error. Checking again soon.`)
+        throw new Error('continue')
+      }
+    }
+
+    log.debug(`statefulSet '${namespace}.${name}' status - '${JSON.stringify(result.status, null, 2)}'`)
+    if (outcome === 'creation' && result.status.readyReplicas > 0) {
+      return result
+    } else if (outcome === 'updated' && result.status.readyReplicas > 0) {
+      return result
+    } else if (outcome === 'deletion' && result.status.phase !== 'Terminating') {
+      return result
+    }
+
+    throw new Error('continue')
+  })
 }
 
-function createStatefulSet (client, deletes, statefulSet) {
+async function createStatefulSet (client, deletes, statefulSet) {
   const namespace = statefulSet.metadata.namespace || 'default'
   const name = statefulSet.metadata.name
-  let create = (resolve, reject) =>
-    multiple(client, namespace).create(statefulSet)
-    .then(
-      result => {
-        checkStatefulSet(client, namespace, name, 'creation', resolve)
-      },
-      err => {
-        reject(new Error(`StatefulSet '${namespace}.${name}' failed to create:\n\t${err.message}`))
+  let create = async () => {
+    await multiple(client, namespace).create(statefulSet)
+      .catch(err => {
+        throw new Error(`StatefulSet '${namespace}.${name}' failed to create:\n\t${err.message}`)
+      })
+
+    await checkStatefulSet(client, namespace, name, 'creation')
+  }
+
+  try {
+    var loaded = await single(client, namespace, name).get()
+  } catch (e) {
+    return create()
+  }
+  const diff = diffs.simple(loaded, statefulSet)
+  if (!_.isEmpty(diff)) {
+    if (diffs.canPatch(diff)) {
+      if (client.saveDiffs) {
+        diffs.save(loaded, statefulSet, diff)
       }
-    )
-  return new Promise((resolve, reject) => {
-    single(client, namespace, name).get()
-      .then(
-        loaded => {
-          const diff = diffs.simple(loaded, statefulSet)
-          if (_.isEmpty(diff)) {
-            resolve()
-          } else {
-            if (diffs.canPatch(diff)) {
-              if (client.saveDiffs) {
-                diffs.save(loaded, statefulSet, diff)
-              }
-              updateStatefulSet(client, namespace, name, diff)
-                .then(
-                  resolve,
-                  reject
-                )
-            } else if (diffs.canReplace(diff)) {
-              replaceStatefulSet(client, namespace, name, statefulSet)
-                .then(
-                  resolve,
-                  reject
-                )
-            } else {
-              deleteStatefulSet(client, namespace, name)
-                .then(
-                  create.bind(null, resolve, reject),
-                  reject
-                )
-            }
-          }
-        },
-        create.bind(null, resolve, reject)
-      )
-  })
+      await updateStatefulSet(client, namespace, name, diff)
+    } else if (diffs.canReplace(diff)) {
+      await replaceStatefulSet(client, namespace, name, statefulSet)
+    } else {
+      await deleteStatefulSet(client, namespace, name)
+      await create()
+    }
+  }
 }
 
-function deleteStatefulSet (client, namespace, name) {
-  return new Promise((resolve, reject) => {
-    single(client, namespace, name).get()
-      .then(
-        () => {
-          single(client, namespace, name).delete()
-            .then(
-              result => {
-                checkStatefulSet(client, namespace, name, 'deletion', resolve)
-              },
-              err => {
-                reject(new Error(`StatefulSet '${namespace}.${name}' could not be deleted:\n\t${err.message}`))
-              }
-            )
-        },
-        () => { resolve() }
-      )
-  })
+async function deleteStatefulSet (client, namespace, name) {
+  try {
+    await single(client, namespace, name).get()
+  } catch (e) {
+    return
+  }
+  await single(client, namespace, name).delete()
+    .catch(err => {
+      throw new Error(`StatefulSet '${namespace}.${name}' could not be deleted:\n\t${err.message}`)
+    })
+  await checkStatefulSet(client, namespace, name, 'deletion')
 }
 
-function getStatefulSetsByNamespace (client, namespace, baseImage) {
-  return listStatefulSets(client, namespace)
-      .then(
-        list => {
-          let statefulSets = _.reduce(list.items, (acc, spec) => {
-            const containers = core.getContainersFromSpec(spec, baseImage)
-            containers.forEach(container => {
-              const metadata = parse(container.image)
-              acc.push({
-                namespace: namespace,
-                type: 'StatefulSet',
-                service: spec.metadata.name,
-                image: container.image,
-                container: container.name,
-                metadata: metadata,
-                labels: spec.spec.template.metadata
-                  ? spec.spec.template.metadata.labels
-                  : metadata.labels || {}
-              })
-            })
-            return acc
-          }, [])
-          return { namespace, statefulSets }
-        }
-      )
+async function getStatefulSetsByNamespace (client, namespace, baseImage) {
+  const list = await listStatefulSets(client, namespace)
+  let statefulSets = _.reduce(list.items, (acc, spec) => {
+    const containers = core.getContainersFromSpec(spec, baseImage)
+    containers.forEach(container => {
+      const metadata = parse(container.image)
+      acc.push({
+        namespace: namespace,
+        type: 'StatefulSet',
+        service: spec.metadata.name,
+        image: container.image,
+        container: container.name,
+        metadata: metadata,
+        labels: spec.spec.template.metadata
+          ? spec.spec.template.metadata.labels
+          : metadata.labels || {}
+      })
+    })
+    return acc
+  }, [])
+
+  return { namespace, statefulSets }
 }
 
-function listStatefulSets (client, namespace) {
+async function listStatefulSets (client, namespace) {
   return multiple(client, namespace).list()
 }
 
-function replaceStatefulSet (client, namespace, name, spec) {
-  return new Promise((resolve, reject) => {
-    single(client, namespace, name).update(spec)
-      .then(
-        result => {
-          checkStatefulSet(client, namespace, name, 'updated', resolve)
-        },
-        err => {
-          reject(new Error(`StatefulSet '${namespace}.${name}' failed to replace:\n\t${err.message}`))
-        }
-      )
-  })
+async function replaceStatefulSet (client, namespace, name, spec) {
+  await single(client, namespace, name).update(spec)
+    .catch(err => {
+      throw new Error(`StatefulSet '${namespace}.${name}' failed to replace:\n\t${err.message}`)
+    })
+  await checkStatefulSet(client, namespace, name, 'updated')
 }
 
-function updateStatefulSet (client, namespace, name, patch) {
-  return new Promise((resolve, reject) => {
-    single(client, namespace, name).patch(patch)
-      .then(
-        result => {
-          checkStatefulSet(client, namespace, name, 'updated', resolve)
-        },
-        err => {
-          reject(new Error(`StatefulSet '${namespace}.${name}' failed to update:\n\t${err.message}`))
-        }
-      )
-  })
+async function updateStatefulSet (client, namespace, name, patch) {
+  await single(client, namespace, name).patch(patch)
+    .catch(err => {
+      throw new Error(`StatefulSet '${namespace}.${name}' failed to update:\n\t${err.message}`)
+    })
+  await checkStatefulSet(client, namespace, name, 'updated')
 }
 
-function upgradeStatefulSet (client, namespace, name, image, container) {
+async function upgradeStatefulSet (client, namespace, name, image, container) {
   const patch = diffs.getImagePatch(container || name, image)
-  return new Promise((resolve, reject) => {
-    single(client, namespace, name).patch(patch)
-      .then(
-        result => {
-          checkStatefulSet(client, namespace, name, 'update', resolve)
-        },
-        err => {
-          reject(new Error(`StatefulSet '${namespace}.${name}' failed to upgrade:\n\t${err.message}`))
-        }
-      )
-  })
+  await single(client, namespace, name).patch(patch)
+    .catch(err => {
+      throw new Error(`StatefulSet '${namespace}.${name}' failed to upgrade:\n\t${err.message}`)
+    })
+  await checkStatefulSet(client, namespace, name, 'update')
 }
 
 module.exports = function (client, deletes) {

--- a/src/k8s/statefulSet.js
+++ b/src/k8s/statefulSet.js
@@ -1,6 +1,5 @@
 const _ = require('lodash')
 const log = require('bole')('k8s')
-const Promise = require('bluebird')
 const core = require('./core')
 const diffs = require('./specDiff')
 const parse = require('../imageParser').parse

--- a/src/k8s/statefulSet.js
+++ b/src/k8s/statefulSet.js
@@ -42,7 +42,7 @@ async function checkStatefulSet (client, namespace, name, outcome) {
         return
       } else {
         log.debug(`statefulSet '${namespace}.${name}' status check got API error. Checking again soon.`)
-        throw new Error('continue')
+        throw new Error('stateful set not ready yet')
       }
     }
 
@@ -55,7 +55,7 @@ async function checkStatefulSet (client, namespace, name, outcome) {
       return result
     }
 
-    throw new Error('continue')
+    throw new Error('stateful set not ready yet')
   })
 }
 

--- a/src/retry.js
+++ b/src/retry.js
@@ -1,0 +1,12 @@
+'use strict'
+
+const asyncRetry = require('async-retry')
+
+module.exports = async function retry (asyncFn, wait = 500, retries = 20) {
+  return asyncRetry(asyncFn, {
+    retries,
+    factor: 1.5,
+    minTimeout: wait,
+    maxTimeout: 5000
+  })
+}


### PR DESCRIPTION
I started tweaking things to hunt down a call of `.then()` on an `undefined`, but then accidentally all the modules.  Much more compact!

There is also some opportunity for some further refactoring, to re-use/standardize some of the CRUD operations for k8s entities, but that it might be better in the long run to have a little repetition there.

I also want to write a few spot unit tests for the k8s modules, but worry about solidifying mocks for the kubernetes client that will become obsolete as the official kubernetes API evolves.